### PR TITLE
Match modifiers on override methods.

### DIFF
--- a/FamilySearch.Api/FamilySearchStateFactory.cs
+++ b/FamilySearch.Api/FamilySearchStateFactory.cs
@@ -80,7 +80,7 @@ namespace FamilySearch.Api
             return new FamilySearchPlaces(request, response, client, accessToken, this);
         }
 
-        protected override CollectionState NewCollectionState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
+		protected internal override CollectionState NewCollectionState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
         {
             return new FamilySearchCollectionState(request, response, client, accessToken, this);
         }
@@ -90,7 +90,7 @@ namespace FamilySearch.Api
             return this.NewCollectionStateInt(request, response, client, accessToken);
         }
 
-        protected override SourceDescriptionState NewSourceDescriptionState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
+		protected internal override SourceDescriptionState NewSourceDescriptionState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
         {
             return new FamilySearchSourceDescriptionState(request, response, client, accessToken, this);
         }
@@ -100,7 +100,7 @@ namespace FamilySearch.Api
             return this.NewSourceDescriptionState(request, response, client, accessToken);
         }
 
-        protected override PersonState NewPersonState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
+		protected internal override PersonState NewPersonState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
         {
             return base.NewPersonState(request, response, client, accessToken);
         }
@@ -120,12 +120,12 @@ namespace FamilySearch.Api
             return new FamilySearchPlaceState(request, response, client, accessToken, this);
         }
 
-        protected override PlaceDescriptionState NewPlaceDescriptionState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
+		protected internal override PlaceDescriptionState NewPlaceDescriptionState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
         {
             return new FamilySearchPlaceDescriptionState(request, response, client, accessToken, this);
         }
 
-        protected override IFilterableRestClient LoadDefaultClient(Uri uri)
+		protected internal override IFilterableRestClient LoadDefaultClient(Uri uri)
         {
             var client = base.LoadDefaultClient(uri);
 

--- a/FamilySearch.Api/Ft/FamilyTreeStateFactory.cs
+++ b/FamilySearch.Api/Ft/FamilyTreeStateFactory.cs
@@ -31,7 +31,7 @@ namespace FamilySearch.Api.Ft
             return new ChildAndParentsRelationshipState(request, response, client, accessToken, this);
         }
 
-        protected override RelationshipsState NewRelationshipsState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
+		protected internal override RelationshipsState NewRelationshipsState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
         {
             return new FamilyTreeRelationshipsState(request, response, client, accessToken, this);
         }
@@ -41,17 +41,17 @@ namespace FamilySearch.Api.Ft
             return this.NewRelationshipsState(request, response, client, accessToken);
         }
 
-        protected override CollectionState NewCollectionState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
+		protected internal override CollectionState NewCollectionState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
         {
             return new FamilySearchFamilyTree(request, response, client, accessToken, this);
         }
 
-        protected override PersonState NewPersonState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
+		protected internal override PersonState NewPersonState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
         {
             return new FamilyTreePersonState(request, response, client, accessToken, this);
         }
 
-        protected override RelationshipState NewRelationshipState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
+		protected internal override RelationshipState NewRelationshipState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
         {
             return new FamilyTreeRelationshipState(request, response, client, accessToken, this);
         }
@@ -61,12 +61,12 @@ namespace FamilySearch.Api.Ft
             return this.NewRelationshipState(request, response, client, accessToken);
         }
 
-        protected override PersonParentsState NewPersonParentsState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
+		protected internal override PersonParentsState NewPersonParentsState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
         {
             return new FamilyTreePersonParentsState(request, response, client, accessToken, this);
         }
 
-        protected override PersonChildrenState NewPersonChildrenState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
+		protected internal override PersonChildrenState NewPersonChildrenState(IRestRequest request, IRestResponse response, IFilterableRestClient client, String accessToken)
         {
             return new FamilyTreePersonChildrenState(request, response, client, accessToken, this);
         }

--- a/Gedcomx.Model.Fs/ChildAndParentsRelationship.cs
+++ b/Gedcomx.Model.Fs/ChildAndParentsRelationship.cs
@@ -126,7 +126,7 @@ namespace Gx.Fs.Tree
             visitor.VisitChildAndParentsRelationship(this);
         }
 
-        protected override void Embed(ExtensibleData relationship)
+        protected internal override void Embed(ExtensibleData relationship)
         {
             ChildAndParentsRelationship value = relationship as ChildAndParentsRelationship;
 

--- a/Gedcomx.Model.Fs/Discussion.cs
+++ b/Gedcomx.Model.Fs/Discussion.cs
@@ -228,7 +228,7 @@ namespace Gx.Fs.Discussions
             visitor.VisitDiscussion(this);
         }
 
-        protected override void Embed(ExtensibleData value)
+        protected internal override void Embed(ExtensibleData value)
         {
             Discussion discussion = value as Discussion;
             List<Comment> comments = discussion.Comments;


### PR DESCRIPTION
Compiler errors were being caused because an override method modifiers must match the base method's modifiers.
