### PR TITLE
Fix Null Reference Exception in PersonState.ReadSpouse

### DIFF
--- a/Gedcomx.Rs.Api/PersonState.cs
+++ b/Gedcomx.Rs.Api/PersonState.cs
@@ -795,7 +795,7 @@ namespace Gx.Rs.Api
         public PersonState ReadSpouse(int index, params StateTransitionOption[] options)
         {
             List<Relationship> spouseRelationships = GetSpouseRelationships();
-            if (spouseRelationships.Count <= index)
+			if (spouseRelationships == null || spouseRelationships.Count <= index)
             {
                 return null;
             }


### PR DESCRIPTION
Null Reference Exception no longer thrown when PersonState.GetSpouseRelationships returns null (no spouse).
