### PR TITLE
Added redirectable rest request support.

### DIFF
--- a/FamilySearch.Api/FamilySearchCollectionState.cs
+++ b/FamilySearch.Api/FamilySearchCollectionState.cs
@@ -48,7 +48,7 @@ namespace FamilySearch.Api
         /// <param name="client">The REST API client to use for API calls.</param>
         /// <param name="stateFactory">The state factory to use for state instantiation.</param>
         private FamilySearchCollectionState(Uri uri, IFilterableRestClient client, FamilySearchStateFactory stateFactory)
-            : this(new RestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(uri, Method.GET), client, stateFactory)
+            : this(new RedirectableRestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(uri, Method.GET), client, stateFactory)
         {
         }
 

--- a/FamilySearch.Api/FamilySearchPlaces.cs
+++ b/FamilySearch.Api/FamilySearchPlaces.cs
@@ -69,7 +69,7 @@ namespace FamilySearch.Api
         /// <param name="client">The REST API client to use for API calls.</param>
         /// <param name="stateFactory">The state factory to use for state instantiation.</param>
         private FamilySearchPlaces(Uri uri, IFilterableRestClient client, FamilySearchStateFactory stateFactory)
-            : this(new RestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(uri, Method.GET), client, stateFactory)
+            : this(new RedirectableRestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(uri, Method.GET), client, stateFactory)
         {
         }
 

--- a/FamilySearch.Api/FamilySearchStateFactory.cs
+++ b/FamilySearch.Api/FamilySearchStateFactory.cs
@@ -127,7 +127,7 @@ namespace FamilySearch.Api
         /// </returns>
         public FamilySearchPlaces NewPlacesState(Uri discoveryUri, IFilterableRestClient client, Method method)
         {
-            IRestRequest request = new RestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(discoveryUri, method);
+            IRestRequest request = new RedirectableRestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(discoveryUri, method);
             return NewPlacesState(request, client.Handle(request), client, null);
         }
 

--- a/FamilySearch.Api/Ft/FamilySearchFamilyTree.cs
+++ b/FamilySearch.Api/Ft/FamilySearchFamilyTree.cs
@@ -76,7 +76,7 @@ namespace FamilySearch.Api.Ft
         /// <param name="client">The REST API client to use for API calls.</param>
         /// <param name="stateFactory">The state factory to use for state instantiation.</param>
         private FamilySearchFamilyTree(Uri uri, IFilterableRestClient client, FamilyTreeStateFactory stateFactory)
-            : this(new RestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(uri, Method.GET), client, stateFactory)
+            : this(new RedirectableRestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(uri, Method.GET), client, stateFactory)
         {
         }
 

--- a/FamilySearch.Api/Ft/FamilyTreePersonState.cs
+++ b/FamilySearch.Api/Ft/FamilyTreePersonState.cs
@@ -48,7 +48,7 @@ namespace FamilySearch.Api.Ft
         /// <param name="client">The REST API client to use for API calls.</param>
         /// <param name="stateFactory">The state factory to use for state instantiation.</param>
         private FamilyTreePersonState(Uri uri, IFilterableRestClient client, FamilyTreeStateFactory stateFactory)
-            : this(new RestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(uri, Method.GET), client, stateFactory)
+            : this(new RedirectableRestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(uri, Method.GET), client, stateFactory)
         {
         }
 

--- a/FamilySearch.Api/Memories/FamilySearchMemories.cs
+++ b/FamilySearch.Api/Memories/FamilySearchMemories.cs
@@ -68,7 +68,7 @@ namespace FamilySearch.Api.Memories
         /// <param name="client">The REST API client to use for API calls.</param>
         /// <param name="stateFactory">The state factory to use for state instantiation.</param>
         private FamilySearchMemories(Uri uri, IFilterableRestClient client, FamilySearchStateFactory stateFactory)
-            : this(new RestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(uri, Method.GET), client, stateFactory)
+            : this(new RedirectableRestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(uri, Method.GET), client, stateFactory)
         {
         }
 

--- a/Gedcomx.Rs.Api.Test/AuthenticationTests.cs
+++ b/Gedcomx.Rs.Api.Test/AuthenticationTests.cs
@@ -25,7 +25,7 @@ namespace Gedcomx.Rs.Api.Test
             collection.AuthenticateViaOAuth2Password(Resources.TestUserName, Resources.TestPassword, Resources.TestClientId);
             Assert.IsTrue(collection.IsAuthenticated);
             Link link = collection.GetLink(Rel.OAUTH2_TOKEN);
-            IRestRequest request = new RestRequest()
+            IRestRequest request = new RedirectableRestRequest()
                 .Accept(MediaTypes.APPLICATION_JSON_TYPE)
                 .Build(link.Href + "?access_token=" + collection.CurrentAccessToken, Method.DELETE);
             IRestResponse response = collection.Client.Handle(request);
@@ -41,7 +41,7 @@ namespace Gedcomx.Rs.Api.Test
             formData.Add("grant_type", "authorization_code");
             formData.Add("code", "tGzv3JOkF0XG5Qx2TlKWIA");
             formData.Add("client_id", "WCQY-7J1Q-GKVV-7DNM-SQ5M-9Q5H-JX3H-CMJK");
-            IRestRequest request = new RestRequest()
+            IRestRequest request = new RedirectableRestRequest()
                 .Accept(MediaTypes.APPLICATION_JSON_TYPE)
                 .ContentType(MediaTypes.APPLICATION_FORM_URLENCODED_TYPE)
                 .SetEntity(formData)
@@ -80,7 +80,7 @@ namespace Gedcomx.Rs.Api.Test
             formData.Add("response_type", "code");
             formData.Add("client_id", "ABCD-EFGH-JKLM-NOPQ-RSTU-VWXY-0123-4567");
             formData.Add("redirect_uri", "https://familysearch.org/developers/sandbox-oauth2-redirect");
-            IRestRequest request = new RestRequest()
+            IRestRequest request = new RedirectableRestRequest()
                 .SetEntity(formData)
                 .Build(tokenLink.Href, Method.GET);
             IRestResponse response = collection.Client.Handle(request);
@@ -100,7 +100,7 @@ namespace Gedcomx.Rs.Api.Test
             formData.Add("response_type", "authorize_me");
             formData.Add("client_id", "ABCD-EFGH-JKLM-NOPQ-RSTU-VWXY-0123-4567");
             formData.Add("redirect_uri", "https://familysearch.org/developers/sandbox-oauth2-redirect");
-            IRestRequest request = new RestRequest()
+            IRestRequest request = new RedirectableRestRequest()
                 .ContentType(MediaTypes.APPLICATION_FORM_URLENCODED_TYPE)
                 .SetEntity(formData)
                 .Build(tokenLink.Href, Method.POST);
@@ -120,7 +120,7 @@ namespace Gedcomx.Rs.Api.Test
             formData.Add("response_type", "code");
             formData.Add("client_id", "ABCD-EFGH-JKLM-NOPQ-RSTU-VWXY-0123-4567");
             formData.Add("redirect_uri", "https://familysearch.org/developers/sandbox-oauth2-redirect");
-            IRestRequest request = new RestRequest()
+            IRestRequest request = new RedirectableRestRequest()
                 .SetEntity(formData)
                 .Build(tokenLink.Href, Method.POST);
             IRestResponse response = collection.Client.Handle(request);

--- a/Gedcomx.Rs.Api.Test/MemoriesTests.cs
+++ b/Gedcomx.Rs.Api.Test/MemoriesTests.cs
@@ -63,7 +63,7 @@ namespace Gedcomx.Rs.Api.Test
             artifacts.Add(dataSource1);
             artifacts.Add(dataSource2);
 
-            IRestRequest request = new RestRequest()
+            IRestRequest request = new RedirectableRestRequest()
                 .AddHeader("Authorization", "Bearer " + tree.CurrentAccessToken)
                 .Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE)
                 .ContentType(MediaTypes.MULTIPART_FORM_DATA_TYPE)

--- a/Gedcomx.Rs.Api.Test/OrdinancesTests.cs
+++ b/Gedcomx.Rs.Api.Test/OrdinancesTests.cs
@@ -21,7 +21,7 @@ namespace Gedcomx.Rs.Api.Test
         [Test]
         public void TestReadOrdinancePolicy()
         {
-            var request = new RestRequest("/platform/ordinances/policy", Method.GET).Accept("text/html");
+            var request = new RedirectableRestRequest("/platform/ordinances/policy", Method.GET).Accept("text/html");
             var client = new FilterableRestClient("https://sandbox.familysearch.org");
             var response = client.Execute(request);
 
@@ -32,7 +32,7 @@ namespace Gedcomx.Rs.Api.Test
         [Test]
         public void TestReadOrdinancePolicyInFrench()
         {
-            var request = new RestRequest("/platform/ordinances/policy", Method.GET).Accept("text/html").AcceptLanguage("fr");
+            var request = new RedirectableRestRequest("/platform/ordinances/policy", Method.GET).Accept("text/html").AcceptLanguage("fr");
             var client = new FilterableRestClient("https://sandbox.familysearch.org");
             var response = client.Execute(request);
 

--- a/Gedcomx.Rs.Api.Test/UtilitiesTests.cs
+++ b/Gedcomx.Rs.Api.Test/UtilitiesTests.cs
@@ -50,7 +50,7 @@ namespace Gedcomx.Rs.Api.Test
             tempTree.AuthenticateViaOAuth2Password(Resources.TestUserName, Resources.TestPassword, Resources.TestClientId);
 
             // Get all the features that are pending
-            IRestRequest request = new RestRequest()
+            IRestRequest request = new RedirectableRestRequest()
                 .Accept(MediaTypes.APPLICATION_JSON_TYPE)
                 .Build("https://sandbox.familysearch.org/platform/pending-modifications", Method.GET);
             IRestResponse response = tempTree.Client.Handle(request);
@@ -90,7 +90,7 @@ namespace Gedcomx.Rs.Api.Test
             var person = tree.AddPerson(TestBacking.GetCreateMalePerson());
             cleanup.Add(person);
             var id = person.Response.Headers.Get("X-ENTITY-ID").Single().Value.ToString();
-            IRestRequest request = new RestRequest()
+            IRestRequest request = new RedirectableRestRequest()
                 .Accept(MediaTypes.APPLICATION_JSON_TYPE)
                 .Build("https://sandbox.familysearch.org/platform/redirect?person=" + id, Method.GET);
             var response = tree.Client.Execute(request);
@@ -105,7 +105,7 @@ namespace Gedcomx.Rs.Api.Test
             var person = tree.AddPerson(TestBacking.GetCreateMalePerson());
             cleanup.Add(person);
             var id = person.Response.Headers.Get("X-ENTITY-ID").Single().Value.ToString();
-            IRestRequest request = new RestRequest()
+            IRestRequest request = new RedirectableRestRequest()
                 .Accept(MediaTypes.APPLICATION_JSON_TYPE)
                 .Build("https://sandbox.familysearch.org/platform/redirect?context=memories&person=" + id, Method.GET);
             var response = tree.Client.Execute(request);
@@ -120,7 +120,7 @@ namespace Gedcomx.Rs.Api.Test
             var person = (FamilyTreePersonState)tree.AddPerson(TestBacking.GetCreateMalePerson()).Get();
             cleanup.Add(person);
             var uri = String.Format("https://sandbox.familysearch.org/platform/redirect?context=sourcelinker&person={0}&hintId={1}", person.Person.Id, person.Person.Identifiers[0].Value);
-            IRestRequest request = new RestRequest()
+            IRestRequest request = new RedirectableRestRequest()
                 .Accept(MediaTypes.APPLICATION_JSON_TYPE)
                 .Build(uri, Method.GET);
             var response = tree.Client.Execute(request);
@@ -132,7 +132,7 @@ namespace Gedcomx.Rs.Api.Test
         [Test]
         public void TestRedirectToUri()
         {
-            IRestRequest request = new RestRequest()
+            IRestRequest request = new RedirectableRestRequest()
                 .Accept(MediaTypes.APPLICATION_JSON_TYPE)
                 .Build("https://sandbox.familysearch.org/platform/redirect?uri=https://familysearch.org/some/path?p1%3Dp1-value%26p2%3Dp2-value", Method.GET);
             var response = tree.Client.Execute(request);

--- a/Gedcomx.Rs.Api/CollectionState.cs
+++ b/Gedcomx.Rs.Api/CollectionState.cs
@@ -51,7 +51,7 @@ namespace Gx.Rs.Api
         /// <param name="client">The REST API client to use for API calls.</param>
         /// <param name="stateFactory">The state factory to use for state instantiation.</param>
         private CollectionState(Uri uri, IFilterableRestClient client, StateFactory stateFactory)
-            : this(new RestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(uri, Method.GET), client, stateFactory)
+            : this(new RedirectableRestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(uri, Method.GET), client, stateFactory)
         {
         }
 

--- a/Gedcomx.Rs.Api/Gedcomx.Rs.Api.csproj
+++ b/Gedcomx.Rs.Api/Gedcomx.Rs.Api.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Util\PagedFeedEnumerator.cs" />
     <Compile Include="Util\FilterableRestClient.cs" />
     <Compile Include="Util\RdfExtensions.cs" />
+    <Compile Include="Util\RedirectableRestRequest.cs" />
     <Compile Include="Util\RestClientExtensions.cs" />
     <Compile Include="Util\ServiceHelper.cs" />
     <Compile Include="Util\UriExtensions.cs" />

--- a/Gedcomx.Rs.Api/GedcomxApplicationState.cs
+++ b/Gedcomx.Rs.Api/GedcomxApplicationState.cs
@@ -257,7 +257,7 @@ namespace Gx.Rs.Api
         /// <returns>A basic REST API request</returns>
         protected IRestRequest CreateRequest()
         {
-            return new RestRequest();
+            return new RedirectableRestRequest();
         }
 
         /// <summary>

--- a/Gedcomx.Rs.Api/PersonState.cs
+++ b/Gedcomx.Rs.Api/PersonState.cs
@@ -47,7 +47,7 @@ namespace Gx.Rs.Api
         /// <param name="client">The REST API client to use for API calls.</param>
         /// <param name="stateFactory">The state factory to use for state instantiation.</param>
         private PersonState(Uri uri, IFilterableRestClient client, StateFactory stateFactory)
-            : this(new RestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(uri, Method.GET), client, stateFactory)
+            : this(new RedirectableRestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(uri, Method.GET), client, stateFactory)
         {
         }
 

--- a/Gedcomx.Rs.Api/RecordState.cs
+++ b/Gedcomx.Rs.Api/RecordState.cs
@@ -41,7 +41,7 @@ namespace Gx.Rs.Api
         /// <param name="client">The REST API client to use for API calls.</param>
         /// <param name="stateFactory">The state factory to use for state instantiation.</param>
         private RecordState(Uri uri, IFilterableRestClient client, StateFactory stateFactory)
-            : this(new RestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(uri, Method.GET), client, stateFactory)
+            : this(new RedirectableRestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(uri, Method.GET), client, stateFactory)
         {
         }
 

--- a/Gedcomx.Rs.Api/StateFactory.cs
+++ b/Gedcomx.Rs.Api/StateFactory.cs
@@ -55,7 +55,7 @@ namespace Gx.Rs.Api
         /// </returns>
         public CollectionState NewCollectionState(Uri discoveryUri, IFilterableRestClient client, Method method)
         {
-            IRestRequest request = new RestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(discoveryUri, method);
+            IRestRequest request = new RedirectableRestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(discoveryUri, method);
             return NewCollectionState(request, client.Handle(request), client, null);
         }
 
@@ -95,7 +95,7 @@ namespace Gx.Rs.Api
         /// </returns>
         public PersonState NewPersonState(Uri discoveryUri, IFilterableRestClient client, Method method)
         {
-            IRestRequest request = new RestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(discoveryUri, method);
+            IRestRequest request = new RedirectableRestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(discoveryUri, method);
             return NewPersonState(request, client.Handle(request), client, null);
         }
 
@@ -135,7 +135,7 @@ namespace Gx.Rs.Api
         /// </returns>
         public RecordState NewRecordState(Uri discoveryUri, IFilterableRestClient client, Method method)
         {
-            IRestRequest request = new RestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(discoveryUri, method);
+            IRestRequest request = new RedirectableRestRequest().Accept(MediaTypes.GEDCOMX_JSON_MEDIA_TYPE).Build(discoveryUri, method);
             return NewRecordState(request, client.Handle(request), client, null);
         }
 

--- a/Gedcomx.Rs.Api/Util/PagedFeedEnumerator.cs
+++ b/Gedcomx.Rs.Api/Util/PagedFeedEnumerator.cs
@@ -451,7 +451,7 @@ namespace Gx.Rs.Api.Util
             public IRestRequest Provide(IFilterableRestClient client, String uri)
             {
                 client.BaseUrl = new Uri(uri).GetBaseUrl();
-                return new RestRequest(uri);
+                return new RedirectableRestRequest(uri);
             }
         }
 

--- a/Gedcomx.Rs.Api/Util/RedirectableRestRequest.cs
+++ b/Gedcomx.Rs.Api/Util/RedirectableRestRequest.cs
@@ -1,0 +1,75 @@
+﻿using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Gx.Rs.Api.Util
+{
+    /// <summary>
+    /// A RestRequest class that allows for base URL redirection.
+    /// </summary>
+    public class RedirectableRestRequest : RestRequest
+    {
+        /// <summary>
+        /// The base URL for this request. If it is different than the client base URL, this one will be used instead.
+        /// </summary>
+        public string BaseUrl { get; set; }
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public RedirectableRestRequest()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Sets Method property to value of method
+        /// </summary>
+        /// <param name="method">Method to use for this request</param>
+        public RedirectableRestRequest(Method method)
+            : base(method)
+        {
+        }
+
+        /// <summary>
+        /// Sets Resource property
+        /// </summary>
+        /// <param name="resource">Resource to use for this request</param>
+        public RedirectableRestRequest(string resource)
+            : base(resource)
+        {
+        }
+
+        /// <summary>
+        /// Sets Resource property
+        /// </summary>
+        /// <param name="resource">Resource to use for this request</param>
+        public RedirectableRestRequest(Uri resource)
+            : base(resource)
+        {
+        }
+
+        /// <summary>
+        /// Sets Resource and Method properties
+        /// </summary>
+        /// <param name="resource">Resource to use for this request</param>
+        /// <param name="method">Method to use for this request</param>
+        public RedirectableRestRequest(string resource, Method method)
+            : base(resource, method)
+        {
+        }
+
+        /// <summary>
+        /// Sets Resource and Method properties
+        /// </summary>
+        /// <param name="resource">Resource to use for this request</param>
+        /// <param name="method">Method to use for this request</param>
+        public RedirectableRestRequest(Uri resource, Method method)
+            : base(resource, method)
+        {
+        }
+    }
+}

--- a/Gedcomx.Rs.Api/Util/RestClientExtensions.cs
+++ b/Gedcomx.Rs.Api/Util/RestClientExtensions.cs
@@ -86,9 +86,16 @@ namespace Gx.Rs.Api.Util
         /// </returns>
         public static IRestRequest Build(this IRestRequest @this, Uri uri, Method method)
         {
+            var redirectable = @this as RedirectableRestRequest;
+
             @this.RequestFormat = @this.GetDataFormat();
             @this.Resource = uri.PathAndQuery;
             @this.Method = method;
+
+            if (redirectable != null)
+            {
+                redirectable.BaseUrl = uri.GetLeftPart(UriPartial.Authority);
+            }
 
             return @this;
         }


### PR DESCRIPTION
This should be a backwards compatible update allowing IRestRequest objects to redirect the client when the resource is on a different domain. Pay particular attention to [RestClientExtensions.cs](https://github.com/shanewalters/gedcomx-csharp/commit/da2922b5ab828119c1b55de1a81177bedbe3baaa#diff-94df0b0f84835249cb7defc53de681bd) and [FilterableRestClient.cs](https://github.com/shanewalters/gedcomx-csharp/commit/da2922b5ab828119c1b55de1a81177bedbe3baaa#diff-0e72ad65e0916c986b2ea1b988b452f8).