### PR TITLE
Migrated GedcomxDate methods to properties

### DIFF
--- a/GEDCOM X Date/GedcomxDate.cs
+++ b/GEDCOM X Date/GedcomxDate.cs
@@ -6,29 +6,29 @@ using System.Threading.Tasks;
 
 namespace Gedcomx.Date
 {
-    /// <summary>
-    /// Represents a basic GEDCOM X date.
-    /// </summary>
-    public abstract class GedcomxDate
-    {
-        /// <summary>
-        /// Gets the type of GEDCOM X date.
-        /// </summary>
-        /// <value>
-        /// The type of GEDCOM X date.
-        /// </value>
-        public abstract GedcomxDateType Type { get; }
+	/// <summary>
+	/// Represents a basic GEDCOM X date.
+	/// </summary>
+	public abstract class GedcomxDate
+	{
+		/// <summary>
+		/// Gets the type of GEDCOM X date.
+		/// </summary>
+		/// <value>
+		/// The type of GEDCOM X date.
+		/// </value>
+		public abstract GedcomxDateType Type { get; }
 
-        /// <summary>
-        /// Determines whether this date is approximate.
-        /// </summary>
-        /// <value><c>true</c> if this date is approximate; otherwise, <c>false</c>.</value>
-        public abstract bool IsApproximate { get; }
+		/// <summary>
+		/// Determines whether this date is approximate.
+		/// </summary>
+		/// <value><c>true</c> if this date is approximate; otherwise, <c>false</c>.</value>
+		public abstract bool IsApproximate { get; }
 
-        /// <summary>
-        /// The formal representation of this date.
-        /// </summary>
-        /// <value>The formal representation of this date.</value>
-        public abstract String FormalString { get; }
-    }
+		/// <summary>
+		/// The formal representation of this date.
+		/// </summary>
+		/// <value>The formal representation of this date.</value>
+		public abstract String FormalString { get; }
+	}
 }

--- a/GEDCOM X Date/GedcomxDate.cs
+++ b/GEDCOM X Date/GedcomxDate.cs
@@ -22,13 +22,13 @@ namespace Gedcomx.Date
         /// <summary>
         /// Determines whether this date is approximate.
         /// </summary>
-        /// <returns><c>true</c> if this date is approximate; otherwise, <c>false</c>.</returns>
-        public abstract bool IsApproximate();
+        /// <value><c>true</c> if this date is approximate; otherwise, <c>false</c>.</value>
+        public abstract bool IsApproximate { get; }
 
         /// <summary>
         /// The formal representation of this date.
         /// </summary>
-        /// <returns>The formal representation of this date.</returns>
-        public abstract String ToFormalString();
+        /// <value>The formal representation of this date.</value>
+        public abstract String FormalString { get; }
     }
 }

--- a/GEDCOM X Date/GedcomxDate.cs
+++ b/GEDCOM X Date/GedcomxDate.cs
@@ -6,29 +6,29 @@ using System.Threading.Tasks;
 
 namespace Gedcomx.Date
 {
-	/// <summary>
-	/// Represents a basic GEDCOM X date.
-	/// </summary>
-	public abstract class GedcomxDate
-	{
-		/// <summary>
-		/// Gets the type of GEDCOM X date.
-		/// </summary>
-		/// <value>
-		/// The type of GEDCOM X date.
-		/// </value>
-		public abstract GedcomxDateType Type { get; }
+    /// <summary>
+    /// Represents a basic GEDCOM X date.
+    /// </summary>
+    public abstract class GedcomxDate
+    {
+        /// <summary>
+        /// Gets the type of GEDCOM X date.
+        /// </summary>
+        /// <value>
+        /// The type of GEDCOM X date.
+        /// </value>
+        public abstract GedcomxDateType Type { get; }
 
-		/// <summary>
-		/// Determines whether this date is approximate.
-		/// </summary>
-		/// <value><c>true</c> if this date is approximate; otherwise, <c>false</c>.</value>
-		public abstract bool IsApproximate { get; }
+        /// <summary>
+        /// Determines whether this date is approximate.
+        /// </summary>
+        /// <value><c>true</c> if this date is approximate; otherwise, <c>false</c>.</value>
+        public abstract bool IsApproximate { get; }
 
-		/// <summary>
-		/// The formal representation of this date.
-		/// </summary>
-		/// <value>The formal representation of this date.</value>
-		public abstract String FormalString { get; }
-	}
+        /// <summary>
+        /// The formal representation of this date.
+        /// </summary>
+        /// <value>The formal representation of this date.</value>
+        public abstract String FormalString { get; }
+    }
 }

--- a/GEDCOM X Date/GedcomxDateApproximate.cs
+++ b/GEDCOM X Date/GedcomxDateApproximate.cs
@@ -6,195 +6,195 @@ using System.Threading.Tasks;
 
 namespace Gedcomx.Date
 {
-  /// <summary>
-  /// Represents an approximate GEDCOM X date.
-  /// </summary>
-  public class GedcomxDateApproximate : GedcomxDate
-  {
-    private GedcomxDateSimple simpleDate;
+	/// <summary>
+	/// Represents an approximate GEDCOM X date.
+	/// </summary>
+	public class GedcomxDateApproximate : GedcomxDate
+	{
+		private GedcomxDateSimple simpleDate;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="GedcomxDateApproximate"/> class.
-    /// </summary>
-    /// <param name="date">The formal duration string that describes a GEDCOM X date approximation.</param>
-    /// <exception cref="GedcomxDateException">Thrown if the specified date is null, empty, or does not begin with 'A' (as required by a formal date string).</exception>
-    public GedcomxDateApproximate(String date)
-    {
-      if (date == null || date.Length < 1 || date[0] != 'A')
-      {
-        throw new GedcomxDateException("Invalid Approximate Date: Must start with A");
-      }
+		/// <summary>
+		/// Initializes a new instance of the <see cref="GedcomxDateApproximate"/> class.
+		/// </summary>
+		/// <param name="date">The formal duration string that describes a GEDCOM X date approximation.</param>
+		/// <exception cref="GedcomxDateException">Thrown if the specified date is null, empty, or does not begin with 'A' (as required by a formal date string).</exception>
+		public GedcomxDateApproximate(String date)
+		{
+			if (date == null || date.Length < 1 || date[0] != 'A')
+			{
+				throw new GedcomxDateException("Invalid Approximate Date: Must start with A");
+			}
 
-      simpleDate = new GedcomxDateSimple(date.Substring(1));
+			simpleDate = new GedcomxDateSimple(date.Substring(1));
 
-    }
+		}
 
-    /// <summary>
-    /// Gets the underlying simple date.
-    /// </summary>
-    /// <value>
-    /// The underlying simple date.
-    /// </value>
-    public GedcomxDateSimple SimpleDate
-    {
-      get
-      {
-        return simpleDate;
-      }
-    }
+		/// <summary>
+		/// Gets the underlying simple date.
+		/// </summary>
+		/// <value>
+		/// The underlying simple date.
+		/// </value>
+		public GedcomxDateSimple SimpleDate
+		{
+			get
+			{
+				return simpleDate;
+			}
+		}
 
-    /// <summary>
-    /// Gets the type of GEDCOM X date. This property always returns APPROXIMATE for this instance.
-    /// </summary>
-    /// <value>
-    /// The type of GEDCOM X date.
-    /// </value>
-    public override GedcomxDateType Type
-    {
-      get
-      {
-        return GedcomxDateType.APPROXIMATE;
-      }
-    }
+		/// <summary>
+		/// Gets the type of GEDCOM X date. This property always returns APPROXIMATE for this instance.
+		/// </summary>
+		/// <value>
+		/// The type of GEDCOM X date.
+		/// </value>
+		public override GedcomxDateType Type
+		{
+			get
+			{
+				return GedcomxDateType.APPROXIMATE;
+			}
+		}
 
-    /// <summary>
-    /// Determines whether this date is approximate. This method always returns <c>true</c> for this instance.
-    /// </summary>
-    /// <value>
-    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-    /// </value>
-    public override bool IsApproximate
-    {
-      get
-      {
-        return true;
-      }
-    }
+		/// <summary>
+		/// Determines whether this date is approximate. This method always returns <c>true</c> for this instance.
+		/// </summary>
+		/// <value>
+		///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+		/// </value>
+		public override bool IsApproximate
+		{
+			get
+			{
+				return true;
+			}
+		}
 
-    /// <summary>
-    /// The formal representation of this date.
-    /// </summary>
-    /// <value>
-    /// The formal representation of this date.
-    /// </value>
-    public override String FormalString
-    {
-      get
-      {
-        return "A" + simpleDate.FormalString;
-      }
-    }
+		/// <summary>
+		/// The formal representation of this date.
+		/// </summary>
+		/// <value>
+		/// The formal representation of this date.
+		/// </value>
+		public override String FormalString
+		{
+			get
+			{
+				return "A" + simpleDate.FormalString;
+			}
+		}
 
-    /// <summary>
-    /// Gets the year of the current date if it exists.
-    /// </summary>
-    /// <value>
-    /// The year of the current date if it exists.
-    /// </value>
-    public Int32? Year
-    {
-      get
-      {
-        return simpleDate.Year;
-      }
-    }
+		/// <summary>
+		/// Gets the year of the current date if it exists.
+		/// </summary>
+		/// <value>
+		/// The year of the current date if it exists.
+		/// </value>
+		public Int32? Year
+		{
+			get
+			{
+				return simpleDate.Year;
+			}
+		}
 
-    /// <summary>
-    /// Gets the month of the current date if it exists.
-    /// </summary>
-    /// <value>
-    /// The month of the current date if it exists.
-    /// </value>
-    public Int32? Month
-    {
-      get
-      {
-        return simpleDate.Month;
-      }
-    }
+		/// <summary>
+		/// Gets the month of the current date if it exists.
+		/// </summary>
+		/// <value>
+		/// The month of the current date if it exists.
+		/// </value>
+		public Int32? Month
+		{
+			get
+			{
+				return simpleDate.Month;
+			}
+		}
 
-    /// <summary>
-    /// Gets the day of the current date if it exists.
-    /// </summary>
-    /// <value>
-    /// The day of the current date if it exists.
-    /// </value>
-    public Int32? Day
-    {
-      get
-      {
-        return simpleDate.Day;
-      }
-    }
+		/// <summary>
+		/// Gets the day of the current date if it exists.
+		/// </summary>
+		/// <value>
+		/// The day of the current date if it exists.
+		/// </value>
+		public Int32? Day
+		{
+			get
+			{
+				return simpleDate.Day;
+			}
+		}
 
-    /// <summary>
-    /// Gets the hours of the current date if it exists.
-    /// </summary>
-    /// <value>
-    /// The hours of the current date if it exists.
-    /// </value>
-    public Int32? Hours
-    {
-      get
-      {
-        return simpleDate.Hours;
-      }
-    }
+		/// <summary>
+		/// Gets the hours of the current date if it exists.
+		/// </summary>
+		/// <value>
+		/// The hours of the current date if it exists.
+		/// </value>
+		public Int32? Hours
+		{
+			get
+			{
+				return simpleDate.Hours;
+			}
+		}
 
-    /// <summary>
-    /// Gets the minutes of the current date if it exists.
-    /// </summary>
-    /// <value>
-    /// The minutes of the current date if it exists.
-    /// </value>
-    public Int32? Minutes
-    {
-      get
-      {
-        return simpleDate.Minutes;
-      }
-    }
+		/// <summary>
+		/// Gets the minutes of the current date if it exists.
+		/// </summary>
+		/// <value>
+		/// The minutes of the current date if it exists.
+		/// </value>
+		public Int32? Minutes
+		{
+			get
+			{
+				return simpleDate.Minutes;
+			}
+		}
 
-    /// <summary>
-    /// Gets the seconds of the current date if it exists.
-    /// </summary>
-    /// <value>
-    /// The seconds of the current date if it exists.
-    /// </value>
-    public Int32? Seconds
-    {
-      get
-      {
-        return simpleDate.Seconds;
-      }
-    }
+		/// <summary>
+		/// Gets the seconds of the current date if it exists.
+		/// </summary>
+		/// <value>
+		/// The seconds of the current date if it exists.
+		/// </value>
+		public Int32? Seconds
+		{
+			get
+			{
+				return simpleDate.Seconds;
+			}
+		}
 
-    /// <summary>
-    /// Gets the timezone hours of the current date if it exists.
-    /// </summary>
-    /// <value>
-    /// The timezone hours of the current date if it exists.
-    /// </value>
-    public Int32? TzHours
-    {
-      get
-      {
-        return simpleDate.TzHours;
-      }
-    }
+		/// <summary>
+		/// Gets the timezone hours of the current date if it exists.
+		/// </summary>
+		/// <value>
+		/// The timezone hours of the current date if it exists.
+		/// </value>
+		public Int32? TzHours
+		{
+			get
+			{
+				return simpleDate.TzHours;
+			}
+		}
 
-    /// <summary>
-    /// Gets the timezone minutes of the current date if it exists.
-    /// </summary>
-    /// <value>
-    /// The timezone minutes of the current date if it exists.
-    /// </value>
-    public Int32? TzMinutes
-    {
-      get
-      {
-        return simpleDate.TzMinutes;
-      }
-    }
-  }
+		/// <summary>
+		/// Gets the timezone minutes of the current date if it exists.
+		/// </summary>
+		/// <value>
+		/// The timezone minutes of the current date if it exists.
+		/// </value>
+		public Int32? TzMinutes
+		{
+			get
+			{
+				return simpleDate.TzMinutes;
+			}
+		}
+	}
 }

--- a/GEDCOM X Date/GedcomxDateApproximate.cs
+++ b/GEDCOM X Date/GedcomxDateApproximate.cs
@@ -6,189 +6,195 @@ using System.Threading.Tasks;
 
 namespace Gedcomx.Date
 {
+  /// <summary>
+  /// Represents an approximate GEDCOM X date.
+  /// </summary>
+  public class GedcomxDateApproximate : GedcomxDate
+  {
+    private GedcomxDateSimple simpleDate;
+
     /// <summary>
-    /// Represents an approximate GEDCOM X date.
+    /// Initializes a new instance of the <see cref="GedcomxDateApproximate"/> class.
     /// </summary>
-    public class GedcomxDateApproximate : GedcomxDate
+    /// <param name="date">The formal duration string that describes a GEDCOM X date approximation.</param>
+    /// <exception cref="GedcomxDateException">Thrown if the specified date is null, empty, or does not begin with 'A' (as required by a formal date string).</exception>
+    public GedcomxDateApproximate(String date)
     {
-        private GedcomxDateSimple simpleDate;
+      if (date == null || date.Length < 1 || date[0] != 'A')
+      {
+        throw new GedcomxDateException("Invalid Approximate Date: Must start with A");
+      }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GedcomxDateApproximate"/> class.
-        /// </summary>
-        /// <param name="date">The formal duration string that describes a GEDCOM X date approximation.</param>
-        /// <exception cref="GedcomxDateException">Thrown if the specified date is null, empty, or does not begin with 'A' (as required by a formal date string).</exception>
-        public GedcomxDateApproximate(String date)
-        {
-            if (date == null || date.Length < 1 || date[0] != 'A')
-            {
-                throw new GedcomxDateException("Invalid Approximate Date: Must start with A");
-            }
+      simpleDate = new GedcomxDateSimple(date.Substring(1));
 
-            simpleDate = new GedcomxDateSimple(date.Substring(1));
-
-        }
-
-        /// <summary>
-        /// Gets the underlying simple date.
-        /// </summary>
-        /// <value>
-        /// The underlying simple date.
-        /// </value>
-        public GedcomxDateSimple SimpleDate
-        {
-            get
-            {
-                return simpleDate;
-            }
-        }
-
-        /// <summary>
-        /// Gets the type of GEDCOM X date. This property always returns APPROXIMATE for this instance.
-        /// </summary>
-        /// <value>
-        /// The type of GEDCOM X date.
-        /// </value>
-        public override GedcomxDateType Type
-        {
-            get
-            {
-                return GedcomxDateType.APPROXIMATE;
-            }
-        }
-
-        /// <summary>
-        /// Determines whether this date is approximate. This method always returns <c>true</c> for this instance.
-        /// </summary>
-        /// <returns>
-        ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-        /// </returns>
-        public override bool IsApproximate()
-        {
-            return true;
-        }
-
-        /// <summary>
-        /// The formal representation of this date.
-        /// </summary>
-        /// <returns>
-        /// The formal representation of this date.
-        /// </returns>
-        public override String ToFormalString()
-        {
-            return "A" + simpleDate.ToFormalString();
-        }
-
-        /// <summary>
-        /// Gets the year of the current date if it exists.
-        /// </summary>
-        /// <value>
-        /// The year of the current date if it exists.
-        /// </value>
-        public Int32? Year
-        {
-            get
-            {
-                return simpleDate.Year;
-            }
-        }
-
-        /// <summary>
-        /// Gets the month of the current date if it exists.
-        /// </summary>
-        /// <value>
-        /// The month of the current date if it exists.
-        /// </value>
-        public Int32? Month
-        {
-            get
-            {
-                return simpleDate.Month;
-            }
-        }
-
-        /// <summary>
-        /// Gets the day of the current date if it exists.
-        /// </summary>
-        /// <value>
-        /// The day of the current date if it exists.
-        /// </value>
-        public Int32? Day
-        {
-            get
-            {
-                return simpleDate.Day;
-            }
-        }
-
-        /// <summary>
-        /// Gets the hours of the current date if it exists.
-        /// </summary>
-        /// <value>
-        /// The hours of the current date if it exists.
-        /// </value>
-        public Int32? Hours
-        {
-            get
-            {
-                return simpleDate.Hours;
-            }
-        }
-
-        /// <summary>
-        /// Gets the minutes of the current date if it exists.
-        /// </summary>
-        /// <value>
-        /// The minutes of the current date if it exists.
-        /// </value>
-        public Int32? Minutes
-        {
-            get
-            {
-                return simpleDate.Minutes;
-            }
-        }
-
-        /// <summary>
-        /// Gets the seconds of the current date if it exists.
-        /// </summary>
-        /// <value>
-        /// The seconds of the current date if it exists.
-        /// </value>
-        public Int32? Seconds
-        {
-            get
-            {
-                return simpleDate.Seconds;
-            }
-        }
-
-        /// <summary>
-        /// Gets the timezone hours of the current date if it exists.
-        /// </summary>
-        /// <value>
-        /// The timezone hours of the current date if it exists.
-        /// </value>
-        public Int32? TzHours
-        {
-            get
-            {
-                return simpleDate.TzHours;
-            }
-        }
-
-        /// <summary>
-        /// Gets the timezone minutes of the current date if it exists.
-        /// </summary>
-        /// <value>
-        /// The timezone minutes of the current date if it exists.
-        /// </value>
-        public Int32? TzMinutes
-        {
-            get
-            {
-                return simpleDate.TzMinutes;
-            }
-        }
     }
+
+    /// <summary>
+    /// Gets the underlying simple date.
+    /// </summary>
+    /// <value>
+    /// The underlying simple date.
+    /// </value>
+    public GedcomxDateSimple SimpleDate
+    {
+      get
+      {
+        return simpleDate;
+      }
+    }
+
+    /// <summary>
+    /// Gets the type of GEDCOM X date. This property always returns APPROXIMATE for this instance.
+    /// </summary>
+    /// <value>
+    /// The type of GEDCOM X date.
+    /// </value>
+    public override GedcomxDateType Type
+    {
+      get
+      {
+        return GedcomxDateType.APPROXIMATE;
+      }
+    }
+
+    /// <summary>
+    /// Determines whether this date is approximate. This method always returns <c>true</c> for this instance.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+    /// </value>
+    public override bool IsApproximate
+    {
+      get
+      {
+        return true;
+      }
+    }
+
+    /// <summary>
+    /// The formal representation of this date.
+    /// </summary>
+    /// <value>
+    /// The formal representation of this date.
+    /// </value>
+    public override String FormalString
+    {
+      get
+      {
+        return "A" + simpleDate.FormalString;
+      }
+    }
+
+    /// <summary>
+    /// Gets the year of the current date if it exists.
+    /// </summary>
+    /// <value>
+    /// The year of the current date if it exists.
+    /// </value>
+    public Int32? Year
+    {
+      get
+      {
+        return simpleDate.Year;
+      }
+    }
+
+    /// <summary>
+    /// Gets the month of the current date if it exists.
+    /// </summary>
+    /// <value>
+    /// The month of the current date if it exists.
+    /// </value>
+    public Int32? Month
+    {
+      get
+      {
+        return simpleDate.Month;
+      }
+    }
+
+    /// <summary>
+    /// Gets the day of the current date if it exists.
+    /// </summary>
+    /// <value>
+    /// The day of the current date if it exists.
+    /// </value>
+    public Int32? Day
+    {
+      get
+      {
+        return simpleDate.Day;
+      }
+    }
+
+    /// <summary>
+    /// Gets the hours of the current date if it exists.
+    /// </summary>
+    /// <value>
+    /// The hours of the current date if it exists.
+    /// </value>
+    public Int32? Hours
+    {
+      get
+      {
+        return simpleDate.Hours;
+      }
+    }
+
+    /// <summary>
+    /// Gets the minutes of the current date if it exists.
+    /// </summary>
+    /// <value>
+    /// The minutes of the current date if it exists.
+    /// </value>
+    public Int32? Minutes
+    {
+      get
+      {
+        return simpleDate.Minutes;
+      }
+    }
+
+    /// <summary>
+    /// Gets the seconds of the current date if it exists.
+    /// </summary>
+    /// <value>
+    /// The seconds of the current date if it exists.
+    /// </value>
+    public Int32? Seconds
+    {
+      get
+      {
+        return simpleDate.Seconds;
+      }
+    }
+
+    /// <summary>
+    /// Gets the timezone hours of the current date if it exists.
+    /// </summary>
+    /// <value>
+    /// The timezone hours of the current date if it exists.
+    /// </value>
+    public Int32? TzHours
+    {
+      get
+      {
+        return simpleDate.TzHours;
+      }
+    }
+
+    /// <summary>
+    /// Gets the timezone minutes of the current date if it exists.
+    /// </summary>
+    /// <value>
+    /// The timezone minutes of the current date if it exists.
+    /// </value>
+    public Int32? TzMinutes
+    {
+      get
+      {
+        return simpleDate.TzMinutes;
+      }
+    }
+  }
 }

--- a/GEDCOM X Date/GedcomxDateApproximate.cs
+++ b/GEDCOM X Date/GedcomxDateApproximate.cs
@@ -6,195 +6,195 @@ using System.Threading.Tasks;
 
 namespace Gedcomx.Date
 {
-  /// <summary>
-  /// Represents an approximate GEDCOM X date.
-  /// </summary>
-  public class GedcomxDateApproximate : GedcomxDate
-  {
-    private GedcomxDateSimple simpleDate;
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="GedcomxDateApproximate"/> class.
+    /// Represents an approximate GEDCOM X date.
     /// </summary>
-    /// <param name="date">The formal duration string that describes a GEDCOM X date approximation.</param>
-    /// <exception cref="GedcomxDateException">Thrown if the specified date is null, empty, or does not begin with 'A' (as required by a formal date string).</exception>
-    public GedcomxDateApproximate(String date)
+    public class GedcomxDateApproximate : GedcomxDate
     {
-      if (date == null || date.Length < 1 || date[0] != 'A')
-      {
-        throw new GedcomxDateException("Invalid Approximate Date: Must start with A");
-      }
+        private GedcomxDateSimple simpleDate;
 
-      simpleDate = new GedcomxDateSimple(date.Substring(1));
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GedcomxDateApproximate"/> class.
+        /// </summary>
+        /// <param name="date">The formal duration string that describes a GEDCOM X date approximation.</param>
+        /// <exception cref="GedcomxDateException">Thrown if the specified date is null, empty, or does not begin with 'A' (as required by a formal date string).</exception>
+        public GedcomxDateApproximate(String date)
+        {
+            if (date == null || date.Length < 1 || date[0] != 'A')
+            {
+                throw new GedcomxDateException("Invalid Approximate Date: Must start with A");
+            }
 
+            simpleDate = new GedcomxDateSimple(date.Substring(1));
+
+        }
+
+        /// <summary>
+        /// Gets the underlying simple date.
+        /// </summary>
+        /// <value>
+        /// The underlying simple date.
+        /// </value>
+        public GedcomxDateSimple SimpleDate
+        {
+            get
+            {
+                return simpleDate;
+            }
+        }
+
+        /// <summary>
+        /// Gets the type of GEDCOM X date. This property always returns APPROXIMATE for this instance.
+        /// </summary>
+        /// <value>
+        /// The type of GEDCOM X date.
+        /// </value>
+        public override GedcomxDateType Type
+        {
+            get
+            {
+                return GedcomxDateType.APPROXIMATE;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether this date is approximate. This method always returns <c>true</c> for this instance.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+        /// </value>
+        public override bool IsApproximate
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// The formal representation of this date.
+        /// </summary>
+        /// <value>
+        /// The formal representation of this date.
+        /// </value>
+        public override String FormalString
+        {
+            get
+            {
+                return "A" + simpleDate.FormalString;
+            }
+        }
+
+        /// <summary>
+        /// Gets the year of the current date if it exists.
+        /// </summary>
+        /// <value>
+        /// The year of the current date if it exists.
+        /// </value>
+        public Int32? Year
+        {
+            get
+            {
+                return simpleDate.Year;
+            }
+        }
+
+        /// <summary>
+        /// Gets the month of the current date if it exists.
+        /// </summary>
+        /// <value>
+        /// The month of the current date if it exists.
+        /// </value>
+        public Int32? Month
+        {
+            get
+            {
+                return simpleDate.Month;
+            }
+        }
+
+        /// <summary>
+        /// Gets the day of the current date if it exists.
+        /// </summary>
+        /// <value>
+        /// The day of the current date if it exists.
+        /// </value>
+        public Int32? Day
+        {
+            get
+            {
+                return simpleDate.Day;
+            }
+        }
+
+        /// <summary>
+        /// Gets the hours of the current date if it exists.
+        /// </summary>
+        /// <value>
+        /// The hours of the current date if it exists.
+        /// </value>
+        public Int32? Hours
+        {
+            get
+            {
+                return simpleDate.Hours;
+            }
+        }
+
+        /// <summary>
+        /// Gets the minutes of the current date if it exists.
+        /// </summary>
+        /// <value>
+        /// The minutes of the current date if it exists.
+        /// </value>
+        public Int32? Minutes
+        {
+            get
+            {
+                return simpleDate.Minutes;
+            }
+        }
+
+        /// <summary>
+        /// Gets the seconds of the current date if it exists.
+        /// </summary>
+        /// <value>
+        /// The seconds of the current date if it exists.
+        /// </value>
+        public Int32? Seconds
+        {
+            get
+            {
+                return simpleDate.Seconds;
+            }
+        }
+
+        /// <summary>
+        /// Gets the timezone hours of the current date if it exists.
+        /// </summary>
+        /// <value>
+        /// The timezone hours of the current date if it exists.
+        /// </value>
+        public Int32? TzHours
+        {
+            get
+            {
+                return simpleDate.TzHours;
+            }
+        }
+
+        /// <summary>
+        /// Gets the timezone minutes of the current date if it exists.
+        /// </summary>
+        /// <value>
+        /// The timezone minutes of the current date if it exists.
+        /// </value>
+        public Int32? TzMinutes
+        {
+            get
+            {
+                return simpleDate.TzMinutes;
+            }
+        }
     }
-
-    /// <summary>
-    /// Gets the underlying simple date.
-    /// </summary>
-    /// <value>
-    /// The underlying simple date.
-    /// </value>
-    public GedcomxDateSimple SimpleDate
-    {
-      get
-      {
-        return simpleDate;
-      }
-    }
-
-    /// <summary>
-    /// Gets the type of GEDCOM X date. This property always returns APPROXIMATE for this instance.
-    /// </summary>
-    /// <value>
-    /// The type of GEDCOM X date.
-    /// </value>
-    public override GedcomxDateType Type
-    {
-      get
-      {
-        return GedcomxDateType.APPROXIMATE;
-      }
-    }
-
-    /// <summary>
-    /// Determines whether this date is approximate. This method always returns <c>true</c> for this instance.
-    /// </summary>
-    /// <value>
-    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-    /// </value>
-    public override bool IsApproximate
-    {
-      get
-      {
-        return true;
-      }
-    }
-
-    /// <summary>
-    /// The formal representation of this date.
-    /// </summary>
-    /// <value>
-    /// The formal representation of this date.
-    /// </value>
-    public override String FormalString
-    {
-      get
-      {
-        return "A" + simpleDate.FormalString;
-      }
-    }
-
-    /// <summary>
-    /// Gets the year of the current date if it exists.
-    /// </summary>
-    /// <value>
-    /// The year of the current date if it exists.
-    /// </value>
-    public Int32? Year
-    {
-      get
-      {
-        return simpleDate.Year;
-      }
-    }
-
-    /// <summary>
-    /// Gets the month of the current date if it exists.
-    /// </summary>
-    /// <value>
-    /// The month of the current date if it exists.
-    /// </value>
-    public Int32? Month
-    {
-      get
-      {
-        return simpleDate.Month;
-      }
-    }
-
-    /// <summary>
-    /// Gets the day of the current date if it exists.
-    /// </summary>
-    /// <value>
-    /// The day of the current date if it exists.
-    /// </value>
-    public Int32? Day
-    {
-      get
-      {
-        return simpleDate.Day;
-      }
-    }
-
-    /// <summary>
-    /// Gets the hours of the current date if it exists.
-    /// </summary>
-    /// <value>
-    /// The hours of the current date if it exists.
-    /// </value>
-    public Int32? Hours
-    {
-      get
-      {
-        return simpleDate.Hours;
-      }
-    }
-
-    /// <summary>
-    /// Gets the minutes of the current date if it exists.
-    /// </summary>
-    /// <value>
-    /// The minutes of the current date if it exists.
-    /// </value>
-    public Int32? Minutes
-    {
-      get
-      {
-        return simpleDate.Minutes;
-      }
-    }
-
-    /// <summary>
-    /// Gets the seconds of the current date if it exists.
-    /// </summary>
-    /// <value>
-    /// The seconds of the current date if it exists.
-    /// </value>
-    public Int32? Seconds
-    {
-      get
-      {
-        return simpleDate.Seconds;
-      }
-    }
-
-    /// <summary>
-    /// Gets the timezone hours of the current date if it exists.
-    /// </summary>
-    /// <value>
-    /// The timezone hours of the current date if it exists.
-    /// </value>
-    public Int32? TzHours
-    {
-      get
-      {
-        return simpleDate.TzHours;
-      }
-    }
-
-    /// <summary>
-    /// Gets the timezone minutes of the current date if it exists.
-    /// </summary>
-    /// <value>
-    /// The timezone minutes of the current date if it exists.
-    /// </value>
-    public Int32? TzMinutes
-    {
-      get
-      {
-        return simpleDate.TzMinutes;
-      }
-    }
-  }
 }

--- a/GEDCOM X Date/GedcomxDateApproximate.cs
+++ b/GEDCOM X Date/GedcomxDateApproximate.cs
@@ -6,195 +6,195 @@ using System.Threading.Tasks;
 
 namespace Gedcomx.Date
 {
-	/// <summary>
-	/// Represents an approximate GEDCOM X date.
-	/// </summary>
-	public class GedcomxDateApproximate : GedcomxDate
-	{
-		private GedcomxDateSimple simpleDate;
+  /// <summary>
+  /// Represents an approximate GEDCOM X date.
+  /// </summary>
+  public class GedcomxDateApproximate : GedcomxDate
+  {
+    private GedcomxDateSimple simpleDate;
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="GedcomxDateApproximate"/> class.
-		/// </summary>
-		/// <param name="date">The formal duration string that describes a GEDCOM X date approximation.</param>
-		/// <exception cref="GedcomxDateException">Thrown if the specified date is null, empty, or does not begin with 'A' (as required by a formal date string).</exception>
-		public GedcomxDateApproximate(String date)
-		{
-			if (date == null || date.Length < 1 || date[0] != 'A')
-			{
-				throw new GedcomxDateException("Invalid Approximate Date: Must start with A");
-			}
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GedcomxDateApproximate"/> class.
+    /// </summary>
+    /// <param name="date">The formal duration string that describes a GEDCOM X date approximation.</param>
+    /// <exception cref="GedcomxDateException">Thrown if the specified date is null, empty, or does not begin with 'A' (as required by a formal date string).</exception>
+    public GedcomxDateApproximate(String date)
+    {
+      if (date == null || date.Length < 1 || date[0] != 'A')
+      {
+        throw new GedcomxDateException("Invalid Approximate Date: Must start with A");
+      }
 
-			simpleDate = new GedcomxDateSimple(date.Substring(1));
+      simpleDate = new GedcomxDateSimple(date.Substring(1));
 
-		}
+    }
 
-		/// <summary>
-		/// Gets the underlying simple date.
-		/// </summary>
-		/// <value>
-		/// The underlying simple date.
-		/// </value>
-		public GedcomxDateSimple SimpleDate
-		{
-			get
-			{
-				return simpleDate;
-			}
-		}
+    /// <summary>
+    /// Gets the underlying simple date.
+    /// </summary>
+    /// <value>
+    /// The underlying simple date.
+    /// </value>
+    public GedcomxDateSimple SimpleDate
+    {
+      get
+      {
+        return simpleDate;
+      }
+    }
 
-		/// <summary>
-		/// Gets the type of GEDCOM X date. This property always returns APPROXIMATE for this instance.
-		/// </summary>
-		/// <value>
-		/// The type of GEDCOM X date.
-		/// </value>
-		public override GedcomxDateType Type
-		{
-			get
-			{
-				return GedcomxDateType.APPROXIMATE;
-			}
-		}
+    /// <summary>
+    /// Gets the type of GEDCOM X date. This property always returns APPROXIMATE for this instance.
+    /// </summary>
+    /// <value>
+    /// The type of GEDCOM X date.
+    /// </value>
+    public override GedcomxDateType Type
+    {
+      get
+      {
+        return GedcomxDateType.APPROXIMATE;
+      }
+    }
 
-		/// <summary>
-		/// Determines whether this date is approximate. This method always returns <c>true</c> for this instance.
-		/// </summary>
-		/// <value>
-		///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-		/// </value>
-		public override bool IsApproximate
-		{
-			get
-			{
-				return true;
-			}
-		}
+    /// <summary>
+    /// Determines whether this date is approximate. This method always returns <c>true</c> for this instance.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+    /// </value>
+    public override bool IsApproximate
+    {
+      get
+      {
+        return true;
+      }
+    }
 
-		/// <summary>
-		/// The formal representation of this date.
-		/// </summary>
-		/// <value>
-		/// The formal representation of this date.
-		/// </value>
-		public override String FormalString
-		{
-			get
-			{
-				return "A" + simpleDate.FormalString;
-			}
-		}
+    /// <summary>
+    /// The formal representation of this date.
+    /// </summary>
+    /// <value>
+    /// The formal representation of this date.
+    /// </value>
+    public override String FormalString
+    {
+      get
+      {
+        return "A" + simpleDate.FormalString;
+      }
+    }
 
-		/// <summary>
-		/// Gets the year of the current date if it exists.
-		/// </summary>
-		/// <value>
-		/// The year of the current date if it exists.
-		/// </value>
-		public Int32? Year
-		{
-			get
-			{
-				return simpleDate.Year;
-			}
-		}
+    /// <summary>
+    /// Gets the year of the current date if it exists.
+    /// </summary>
+    /// <value>
+    /// The year of the current date if it exists.
+    /// </value>
+    public Int32? Year
+    {
+      get
+      {
+        return simpleDate.Year;
+      }
+    }
 
-		/// <summary>
-		/// Gets the month of the current date if it exists.
-		/// </summary>
-		/// <value>
-		/// The month of the current date if it exists.
-		/// </value>
-		public Int32? Month
-		{
-			get
-			{
-				return simpleDate.Month;
-			}
-		}
+    /// <summary>
+    /// Gets the month of the current date if it exists.
+    /// </summary>
+    /// <value>
+    /// The month of the current date if it exists.
+    /// </value>
+    public Int32? Month
+    {
+      get
+      {
+        return simpleDate.Month;
+      }
+    }
 
-		/// <summary>
-		/// Gets the day of the current date if it exists.
-		/// </summary>
-		/// <value>
-		/// The day of the current date if it exists.
-		/// </value>
-		public Int32? Day
-		{
-			get
-			{
-				return simpleDate.Day;
-			}
-		}
+    /// <summary>
+    /// Gets the day of the current date if it exists.
+    /// </summary>
+    /// <value>
+    /// The day of the current date if it exists.
+    /// </value>
+    public Int32? Day
+    {
+      get
+      {
+        return simpleDate.Day;
+      }
+    }
 
-		/// <summary>
-		/// Gets the hours of the current date if it exists.
-		/// </summary>
-		/// <value>
-		/// The hours of the current date if it exists.
-		/// </value>
-		public Int32? Hours
-		{
-			get
-			{
-				return simpleDate.Hours;
-			}
-		}
+    /// <summary>
+    /// Gets the hours of the current date if it exists.
+    /// </summary>
+    /// <value>
+    /// The hours of the current date if it exists.
+    /// </value>
+    public Int32? Hours
+    {
+      get
+      {
+        return simpleDate.Hours;
+      }
+    }
 
-		/// <summary>
-		/// Gets the minutes of the current date if it exists.
-		/// </summary>
-		/// <value>
-		/// The minutes of the current date if it exists.
-		/// </value>
-		public Int32? Minutes
-		{
-			get
-			{
-				return simpleDate.Minutes;
-			}
-		}
+    /// <summary>
+    /// Gets the minutes of the current date if it exists.
+    /// </summary>
+    /// <value>
+    /// The minutes of the current date if it exists.
+    /// </value>
+    public Int32? Minutes
+    {
+      get
+      {
+        return simpleDate.Minutes;
+      }
+    }
 
-		/// <summary>
-		/// Gets the seconds of the current date if it exists.
-		/// </summary>
-		/// <value>
-		/// The seconds of the current date if it exists.
-		/// </value>
-		public Int32? Seconds
-		{
-			get
-			{
-				return simpleDate.Seconds;
-			}
-		}
+    /// <summary>
+    /// Gets the seconds of the current date if it exists.
+    /// </summary>
+    /// <value>
+    /// The seconds of the current date if it exists.
+    /// </value>
+    public Int32? Seconds
+    {
+      get
+      {
+        return simpleDate.Seconds;
+      }
+    }
 
-		/// <summary>
-		/// Gets the timezone hours of the current date if it exists.
-		/// </summary>
-		/// <value>
-		/// The timezone hours of the current date if it exists.
-		/// </value>
-		public Int32? TzHours
-		{
-			get
-			{
-				return simpleDate.TzHours;
-			}
-		}
+    /// <summary>
+    /// Gets the timezone hours of the current date if it exists.
+    /// </summary>
+    /// <value>
+    /// The timezone hours of the current date if it exists.
+    /// </value>
+    public Int32? TzHours
+    {
+      get
+      {
+        return simpleDate.TzHours;
+      }
+    }
 
-		/// <summary>
-		/// Gets the timezone minutes of the current date if it exists.
-		/// </summary>
-		/// <value>
-		/// The timezone minutes of the current date if it exists.
-		/// </value>
-		public Int32? TzMinutes
-		{
-			get
-			{
-				return simpleDate.TzMinutes;
-			}
-		}
-	}
+    /// <summary>
+    /// Gets the timezone minutes of the current date if it exists.
+    /// </summary>
+    /// <value>
+    /// The timezone minutes of the current date if it exists.
+    /// </value>
+    public Int32? TzMinutes
+    {
+      get
+      {
+        return simpleDate.TzMinutes;
+      }
+    }
+  }
 }

--- a/GEDCOM X Date/GedcomxDateDuration.cs
+++ b/GEDCOM X Date/GedcomxDateDuration.cs
@@ -5,381 +5,381 @@ using System.Text;
 
 namespace Gedcomx.Date
 {
-  /// <summary>
-  /// Represents a GEDCOM X date span, measured from years to seconds.
-  /// </summary>
-  public class GedcomxDateDuration : GedcomxDate
-  {
-    private Int32? years = null;
-    private Int32? months = null;
-    private Int32? days = null;
-    private Int32? hours = null;
-    private Int32? minutes = null;
-    private Int32? seconds = null;
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="GedcomxDateDuration"/> class.
+    /// Represents a GEDCOM X date span, measured from years to seconds.
     /// </summary>
-    /// <param name="str">The formal duration string that describes a GEDCOM X duration.</param>
-    /// <exception cref="GedcomxDateException">
-    /// Thrown if the formal string is null, empty, or does not begin with 'P'.
-    /// or
-    /// Thrown if the formal string does not have a duration specified (the string after 'P').
-    /// or
-    /// Thrown if the formal string is a 5.3.2 non-normalized date (these are not yet implemented).
-    /// </exception>
-    public GedcomxDateDuration(String str)
+    public class GedcomxDateDuration : GedcomxDate
     {
-      // Durations must start with P
-      if (str == null || str.Length < 1 || str[0] != 'P')
-      {
-        throw new GedcomxDateException("Invalid Duration: Must start with P");
-      }
+        private Int32? years = null;
+        private Int32? months = null;
+        private Int32? days = null;
+        private Int32? hours = null;
+        private Int32? minutes = null;
+        private Int32? seconds = null;
 
-      String duration = str.Substring(1);
-
-      if (duration.Length < 1)
-      {
-        throw new GedcomxDateException("Invalid Duration: You must have a duration value");
-      }
-
-      // 5.3.2 allows for NON normalized durations
-      // We assume that if there is a space, it is non-normalized
-      if (duration.Contains(" "))
-      {
-        // When we implement non normalized durations we can call parseNonNormalizedDuration(duration)
-        throw new GedcomxDateException("Invalid Duration: Non normalized durations are not implemented yet");
-      }
-      else
-      {
-        ParseNormalizedDuration(duration);
-      }
-    }
-
-    /// <summary>
-    /// Parses the formal duration string and populates the results in this current instance.
-    /// </summary>
-    /// <param name="duration">The formal duration string to be parsed.</param>
-    /// <exception cref="GedcomxDateException">
-    /// Thrown if any of the current parsing expectations fail. A specific reason will be included at runtime.
-    /// </exception>
-    private void ParseNormalizedDuration(String duration)
-    {
-      String currentNum = "";
-      bool inTime = false;
-      HashSet<String> seen = new HashSet<String>();
-      List<String> valid = new List<string>() { "Y", "Mo", "D", "T", "H", "Mi", "S" };
-
-      foreach (char character in duration)
-      {
-        if (Char.IsDigit(character))
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GedcomxDateDuration"/> class.
+        /// </summary>
+        /// <param name="str">The formal duration string that describes a GEDCOM X duration.</param>
+        /// <exception cref="GedcomxDateException">
+        /// Thrown if the formal string is null, empty, or does not begin with 'P'.
+        /// or
+        /// Thrown if the formal string does not have a duration specified (the string after 'P').
+        /// or
+        /// Thrown if the formal string is a 5.3.2 non-normalized date (these are not yet implemented).
+        /// </exception>
+        public GedcomxDateDuration(String str)
         {
-          currentNum += character;
-          continue;
-        }
+            // Durations must start with P
+            if (str == null || str.Length < 1 || str[0] != 'P')
+            {
+                throw new GedcomxDateException("Invalid Duration: Must start with P");
+            }
 
-        switch (character)
-        {
-          case 'Y':
-            if (currentNum.Length < 1)
+            String duration = str.Substring(1);
+
+            if (duration.Length < 1)
             {
-              throw new GedcomxDateException("Invalid Duration: Invalid years");
+                throw new GedcomxDateException("Invalid Duration: You must have a duration value");
             }
-            if (seen.Contains("Y"))
+
+            // 5.3.2 allows for NON normalized durations
+            // We assume that if there is a space, it is non-normalized
+            if (duration.Contains(" "))
             {
-              throw new GedcomxDateException("Invalid Duration: Duplicate years");
-            }
-            if (!valid.Contains("Y"))
-            {
-              throw new GedcomxDateException("Invalid Duration: Years out of order");
-            }
-            this.years = Int32.Parse(currentNum);
-            seen.Add("Y");
-            valid = valid.Skip(valid.IndexOf("Y") + 1).ToList();
-            currentNum = "";
-            break;
-          case 'M':
-            if (inTime)
-            {
-              if (currentNum.Length < 1)
-              {
-                throw new GedcomxDateException("Invalid Duration: Invalid minutes");
-              }
-              if (seen.Contains("Mi"))
-              {
-                throw new GedcomxDateException("Invalid Duration: Duplicate minutes");
-              }
-              if (!valid.Contains("Mi"))
-              {
-                throw new GedcomxDateException("Invalid Duration: Minutes out of order");
-              }
-              this.minutes = Int32.Parse(currentNum);
-              seen.Add("Mi");
-              valid = valid.Skip(valid.IndexOf("Mi") + 1).ToList();
-              currentNum = "";
+                // When we implement non normalized durations we can call parseNonNormalizedDuration(duration)
+                throw new GedcomxDateException("Invalid Duration: Non normalized durations are not implemented yet");
             }
             else
             {
-              if (currentNum.Length < 1)
-              {
-                throw new GedcomxDateException("Invalid Duration: Invalid months");
-              }
-              if (seen.Contains("Mo"))
-              {
-                throw new GedcomxDateException("Invalid Duration: Duplicate months");
-              }
-              if (!valid.Contains("Mo"))
-              {
-                throw new GedcomxDateException("Invalid Duration: Months out of order");
-              }
-              this.months = Int32.Parse(currentNum);
-              seen.Add("Mo");
-              valid = valid.Skip(valid.IndexOf("Mo") + 1).ToList();
-              currentNum = "";
+                ParseNormalizedDuration(duration);
             }
-            break;
-          case 'D':
-            if (currentNum.Length < 1)
-            {
-              throw new GedcomxDateException("Invalid Duration: Invalid days");
-            }
-            if (seen.Contains("D"))
-            {
-              throw new GedcomxDateException("Invalid Duration: Duplicate days");
-            }
-            if (!valid.Contains("D"))
-            {
-              throw new GedcomxDateException("Invalid Duration: Days out of order");
-            }
-            this.days = Int32.Parse(currentNum);
-            seen.Add("D");
-            valid = valid.Skip(valid.IndexOf("D") + 1).ToList();
-            currentNum = "";
-            break;
-          case 'H':
-            if (!inTime)
-            {
-              throw new GedcomxDateException("Invalid Duration: Missing T before hours");
-            }
-            if (currentNum.Length < 1)
-            {
-              throw new GedcomxDateException("Invalid Duration: Invalid hours");
-            }
-            if (seen.Contains("H"))
-            {
-              throw new GedcomxDateException("Invalid Duration: Duplicate hours");
-            }
-            if (!valid.Contains("H"))
-            {
-              throw new GedcomxDateException("Invalid Duration: Hours out of order");
-            }
-            this.hours = Int32.Parse(currentNum);
-            seen.Add("H");
-            valid = valid.Skip(valid.IndexOf("H") + 1).ToList();
-            currentNum = "";
-            break;
-          case 'S':
-            if (!inTime)
-            {
-              throw new GedcomxDateException("Invalid Duration: Missing T before seconds");
-            }
-            if (currentNum.Length < 1)
-            {
-              throw new GedcomxDateException("Invalid Duration: Invalid seconds");
-            }
-            if (seen.Contains("S"))
-            {
-              throw new GedcomxDateException("Invalid Duration: Duplicate seconds");
-            }
-            // You cannot have seconds out of order because it's last
-            this.seconds = Int32.Parse(currentNum);
-            seen.Add("S");
-            valid = new List<String>();
-            currentNum = "";
-            break;
-          case 'T':
-            if (seen.Contains("T"))
-            {
-              throw new GedcomxDateException("Invalid Duration: Duplicate T");
-            }
-            inTime = true;
-            seen.Add("T");
-            valid = valid.Skip(valid.IndexOf("T") + 1).ToList();
-            break;
-          default:
-            throw new GedcomxDateException("Invalid Duration: Unknown letter " + character);
         }
-      }
 
-      // If there is any leftover we have an invalid duration
-      if (!currentNum.Equals(""))
-      {
-        throw new GedcomxDateException("Invalid Duration: No letter after " + currentNum);
-      }
-
-    }
-
-    /// <summary>
-    /// Gets the type of GEDCOM X date. This property always returns APPROXIMATE for this instance.
-    /// </summary>
-    /// <value>
-    /// The type of GEDCOM X date.
-    /// </value>
-    public override GedcomxDateType Type
-    {
-      get
-      {
-        return GedcomxDateType.DURATION;
-      }
-    }
-
-    /// <summary>
-    /// Determines whether this date is approximate.  This method always returns <c>false</c> for this instance.
-    /// </summary>
-    /// <value>
-    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-    /// </value>
-    public override bool IsApproximate
-    {
-      get
-      {
-        return false;
-      }
-    }
-
-    /// <summary>
-    /// The formal representation of this duration.
-    /// </summary>
-    /// <value>
-    /// The formal representation of this duration.
-    /// </value>
-    public override String FormalString
-    {
-      get
-      {
-        StringBuilder duration = new StringBuilder("P");
-
-        if (years != null)
+        /// <summary>
+        /// Parses the formal duration string and populates the results in this current instance.
+        /// </summary>
+        /// <param name="duration">The formal duration string to be parsed.</param>
+        /// <exception cref="GedcomxDateException">
+        /// Thrown if any of the current parsing expectations fail. A specific reason will be included at runtime.
+        /// </exception>
+        private void ParseNormalizedDuration(String duration)
         {
-          duration.Append(years).Append('Y');
+            String currentNum = "";
+            bool inTime = false;
+            HashSet<String> seen = new HashSet<String>();
+            List<String> valid = new List<string>() { "Y", "Mo", "D", "T", "H", "Mi", "S" };
+
+            foreach (char character in duration)
+            {
+                if (Char.IsDigit(character))
+                {
+                    currentNum += character;
+                    continue;
+                }
+
+                switch (character)
+                {
+                    case 'Y':
+                        if (currentNum.Length < 1)
+                        {
+                            throw new GedcomxDateException("Invalid Duration: Invalid years");
+                        }
+                        if (seen.Contains("Y"))
+                        {
+                            throw new GedcomxDateException("Invalid Duration: Duplicate years");
+                        }
+                        if (!valid.Contains("Y"))
+                        {
+                            throw new GedcomxDateException("Invalid Duration: Years out of order");
+                        }
+                        this.years = Int32.Parse(currentNum);
+                        seen.Add("Y");
+                        valid = valid.Skip(valid.IndexOf("Y") + 1).ToList();
+                        currentNum = "";
+                        break;
+                    case 'M':
+                        if (inTime)
+                        {
+                            if (currentNum.Length < 1)
+                            {
+                                throw new GedcomxDateException("Invalid Duration: Invalid minutes");
+                            }
+                            if (seen.Contains("Mi"))
+                            {
+                                throw new GedcomxDateException("Invalid Duration: Duplicate minutes");
+                            }
+                            if (!valid.Contains("Mi"))
+                            {
+                                throw new GedcomxDateException("Invalid Duration: Minutes out of order");
+                            }
+                            this.minutes = Int32.Parse(currentNum);
+                            seen.Add("Mi");
+                            valid = valid.Skip(valid.IndexOf("Mi") + 1).ToList();
+                            currentNum = "";
+                        }
+                        else
+                        {
+                            if (currentNum.Length < 1)
+                            {
+                                throw new GedcomxDateException("Invalid Duration: Invalid months");
+                            }
+                            if (seen.Contains("Mo"))
+                            {
+                                throw new GedcomxDateException("Invalid Duration: Duplicate months");
+                            }
+                            if (!valid.Contains("Mo"))
+                            {
+                                throw new GedcomxDateException("Invalid Duration: Months out of order");
+                            }
+                            this.months = Int32.Parse(currentNum);
+                            seen.Add("Mo");
+                            valid = valid.Skip(valid.IndexOf("Mo") + 1).ToList();
+                            currentNum = "";
+                        }
+                        break;
+                    case 'D':
+                        if (currentNum.Length < 1)
+                        {
+                            throw new GedcomxDateException("Invalid Duration: Invalid days");
+                        }
+                        if (seen.Contains("D"))
+                        {
+                            throw new GedcomxDateException("Invalid Duration: Duplicate days");
+                        }
+                        if (!valid.Contains("D"))
+                        {
+                            throw new GedcomxDateException("Invalid Duration: Days out of order");
+                        }
+                        this.days = Int32.Parse(currentNum);
+                        seen.Add("D");
+                        valid = valid.Skip(valid.IndexOf("D") + 1).ToList();
+                        currentNum = "";
+                        break;
+                    case 'H':
+                        if (!inTime)
+                        {
+                            throw new GedcomxDateException("Invalid Duration: Missing T before hours");
+                        }
+                        if (currentNum.Length < 1)
+                        {
+                            throw new GedcomxDateException("Invalid Duration: Invalid hours");
+                        }
+                        if (seen.Contains("H"))
+                        {
+                            throw new GedcomxDateException("Invalid Duration: Duplicate hours");
+                        }
+                        if (!valid.Contains("H"))
+                        {
+                            throw new GedcomxDateException("Invalid Duration: Hours out of order");
+                        }
+                        this.hours = Int32.Parse(currentNum);
+                        seen.Add("H");
+                        valid = valid.Skip(valid.IndexOf("H") + 1).ToList();
+                        currentNum = "";
+                        break;
+                    case 'S':
+                        if (!inTime)
+                        {
+                            throw new GedcomxDateException("Invalid Duration: Missing T before seconds");
+                        }
+                        if (currentNum.Length < 1)
+                        {
+                            throw new GedcomxDateException("Invalid Duration: Invalid seconds");
+                        }
+                        if (seen.Contains("S"))
+                        {
+                            throw new GedcomxDateException("Invalid Duration: Duplicate seconds");
+                        }
+                        // You cannot have seconds out of order because it's last
+                        this.seconds = Int32.Parse(currentNum);
+                        seen.Add("S");
+                        valid = new List<String>();
+                        currentNum = "";
+                        break;
+                    case 'T':
+                        if (seen.Contains("T"))
+                        {
+                            throw new GedcomxDateException("Invalid Duration: Duplicate T");
+                        }
+                        inTime = true;
+                        seen.Add("T");
+                        valid = valid.Skip(valid.IndexOf("T") + 1).ToList();
+                        break;
+                    default:
+                        throw new GedcomxDateException("Invalid Duration: Unknown letter " + character);
+                }
+            }
+
+            // If there is any leftover we have an invalid duration
+            if (!currentNum.Equals(""))
+            {
+                throw new GedcomxDateException("Invalid Duration: No letter after " + currentNum);
+            }
+
         }
 
-        if (months != null)
+        /// <summary>
+        /// Gets the type of GEDCOM X date. This property always returns APPROXIMATE for this instance.
+        /// </summary>
+        /// <value>
+        /// The type of GEDCOM X date.
+        /// </value>
+        public override GedcomxDateType Type
         {
-          duration.Append(months).Append('M');
+            get
+            {
+                return GedcomxDateType.DURATION;
+            }
         }
 
-        if (days != null)
+        /// <summary>
+        /// Determines whether this date is approximate.  This method always returns <c>false</c> for this instance.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+        /// </value>
+        public override bool IsApproximate
         {
-          duration.Append(days).Append('D');
+            get
+            {
+                return false;
+            }
         }
 
-        if (hours != null || minutes != null || seconds != null)
+        /// <summary>
+        /// The formal representation of this duration.
+        /// </summary>
+        /// <value>
+        /// The formal representation of this duration.
+        /// </value>
+        public override String FormalString
         {
-          duration.Append('T');
+            get
+            {
+                StringBuilder duration = new StringBuilder("P");
 
-          if (hours != null)
-          {
-            duration.Append(hours).Append('H');
-          }
+                if (years != null)
+                {
+                    duration.Append(years).Append('Y');
+                }
 
-          if (minutes != null)
-          {
-            duration.Append(minutes).Append('M');
-          }
+                if (months != null)
+                {
+                    duration.Append(months).Append('M');
+                }
 
-          if (seconds != null)
-          {
-            duration.Append(seconds).Append('S');
-          }
+                if (days != null)
+                {
+                    duration.Append(days).Append('D');
+                }
+
+                if (hours != null || minutes != null || seconds != null)
+                {
+                    duration.Append('T');
+
+                    if (hours != null)
+                    {
+                        duration.Append(hours).Append('H');
+                    }
+
+                    if (minutes != null)
+                    {
+                        duration.Append(minutes).Append('M');
+                    }
+
+                    if (seconds != null)
+                    {
+                        duration.Append(seconds).Append('S');
+                    }
+                }
+
+                return duration.ToString();
+            }
         }
 
-        return duration.ToString();
-      }
-    }
+        /// <summary>
+        /// Gets the years of the current duration if applicable.
+        /// </summary>
+        /// <value>
+        /// The years of the current duration if applicable.
+        /// </value>
+        public Int32? Years
+        {
+            get
+            {
+                return years;
+            }
+        }
 
-    /// <summary>
-    /// Gets the years of the current duration if applicable.
-    /// </summary>
-    /// <value>
-    /// The years of the current duration if applicable.
-    /// </value>
-    public Int32? Years
-    {
-      get
-      {
-        return years;
-      }
-    }
+        /// <summary>
+        /// Gets the months of the current duration if applicable.
+        /// </summary>
+        /// <value>
+        /// The months of the current duration if applicable.
+        /// </value>
+        public Int32? Months
+        {
+            get
+            {
+                return months;
+            }
+        }
 
-    /// <summary>
-    /// Gets the months of the current duration if applicable.
-    /// </summary>
-    /// <value>
-    /// The months of the current duration if applicable.
-    /// </value>
-    public Int32? Months
-    {
-      get
-      {
-        return months;
-      }
-    }
+        /// <summary>
+        /// Gets the days of the current duration if applicable.
+        /// </summary>
+        /// <value>
+        /// The days of the current duration if applicable.
+        /// </value>
+        public Int32? Days
+        {
+            get
+            {
+                return days;
+            }
+        }
 
-    /// <summary>
-    /// Gets the days of the current duration if applicable.
-    /// </summary>
-    /// <value>
-    /// The days of the current duration if applicable.
-    /// </value>
-    public Int32? Days
-    {
-      get
-      {
-        return days;
-      }
-    }
+        /// <summary>
+        /// Gets the hours of the current duration if applicable.
+        /// </summary>
+        /// <value>
+        /// The hours of the current duration if applicable.
+        /// </value>
+        public Int32? Hours
+        {
+            get
+            {
+                return hours;
+            }
+        }
 
-    /// <summary>
-    /// Gets the hours of the current duration if applicable.
-    /// </summary>
-    /// <value>
-    /// The hours of the current duration if applicable.
-    /// </value>
-    public Int32? Hours
-    {
-      get
-      {
-        return hours;
-      }
-    }
+        /// <summary>
+        /// Gets the minutes of the current duration if applicable.
+        /// </summary>
+        /// <value>
+        /// The minutes of the current duration if applicable.
+        /// </value>
+        public Int32? Minutes
+        {
+            get
+            {
+                return minutes;
+            }
+        }
 
-    /// <summary>
-    /// Gets the minutes of the current duration if applicable.
-    /// </summary>
-    /// <value>
-    /// The minutes of the current duration if applicable.
-    /// </value>
-    public Int32? Minutes
-    {
-      get
-      {
-        return minutes;
-      }
+        /// <summary>
+        /// Gets the seconds of the current duration if applicable.
+        /// </summary>
+        /// <value>
+        /// The seconds of the current duration if applicable.
+        /// </value>
+        public Int32? Seconds
+        {
+            get
+            {
+                return seconds;
+            }
+        }
     }
-
-    /// <summary>
-    /// Gets the seconds of the current duration if applicable.
-    /// </summary>
-    /// <value>
-    /// The seconds of the current duration if applicable.
-    /// </value>
-    public Int32? Seconds
-    {
-      get
-      {
-        return seconds;
-      }
-    }
-  }
 }

--- a/GEDCOM X Date/GedcomxDateDuration.cs
+++ b/GEDCOM X Date/GedcomxDateDuration.cs
@@ -5,381 +5,381 @@ using System.Text;
 
 namespace Gedcomx.Date
 {
-	/// <summary>
-	/// Represents a GEDCOM X date span, measured from years to seconds.
-	/// </summary>
-	public class GedcomxDateDuration : GedcomxDate
-	{
-		private Int32? years = null;
-		private Int32? months = null;
-		private Int32? days = null;
-		private Int32? hours = null;
-		private Int32? minutes = null;
-		private Int32? seconds = null;
+  /// <summary>
+  /// Represents a GEDCOM X date span, measured from years to seconds.
+  /// </summary>
+  public class GedcomxDateDuration : GedcomxDate
+  {
+    private Int32? years = null;
+    private Int32? months = null;
+    private Int32? days = null;
+    private Int32? hours = null;
+    private Int32? minutes = null;
+    private Int32? seconds = null;
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="GedcomxDateDuration"/> class.
-		/// </summary>
-		/// <param name="str">The formal duration string that describes a GEDCOM X duration.</param>
-		/// <exception cref="GedcomxDateException">
-		/// Thrown if the formal string is null, empty, or does not begin with 'P'.
-		/// or
-		/// Thrown if the formal string does not have a duration specified (the string after 'P').
-		/// or
-		/// Thrown if the formal string is a 5.3.2 non-normalized date (these are not yet implemented).
-		/// </exception>
-		public GedcomxDateDuration(String str)
-		{
-			// Durations must start with P
-			if (str == null || str.Length < 1 || str[0] != 'P')
-			{
-				throw new GedcomxDateException("Invalid Duration: Must start with P");
-			}
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GedcomxDateDuration"/> class.
+    /// </summary>
+    /// <param name="str">The formal duration string that describes a GEDCOM X duration.</param>
+    /// <exception cref="GedcomxDateException">
+    /// Thrown if the formal string is null, empty, or does not begin with 'P'.
+    /// or
+    /// Thrown if the formal string does not have a duration specified (the string after 'P').
+    /// or
+    /// Thrown if the formal string is a 5.3.2 non-normalized date (these are not yet implemented).
+    /// </exception>
+    public GedcomxDateDuration(String str)
+    {
+      // Durations must start with P
+      if (str == null || str.Length < 1 || str[0] != 'P')
+      {
+        throw new GedcomxDateException("Invalid Duration: Must start with P");
+      }
 
-			String duration = str.Substring(1);
+      String duration = str.Substring(1);
 
-			if (duration.Length < 1)
-			{
-				throw new GedcomxDateException("Invalid Duration: You must have a duration value");
-			}
+      if (duration.Length < 1)
+      {
+        throw new GedcomxDateException("Invalid Duration: You must have a duration value");
+      }
 
-			// 5.3.2 allows for NON normalized durations
-			// We assume that if there is a space, it is non-normalized
-			if (duration.Contains(" "))
-			{
-				// When we implement non normalized durations we can call parseNonNormalizedDuration(duration)
-				throw new GedcomxDateException("Invalid Duration: Non normalized durations are not implemented yet");
-			}
-			else
-			{
-				ParseNormalizedDuration(duration);
-			}
-		}
+      // 5.3.2 allows for NON normalized durations
+      // We assume that if there is a space, it is non-normalized
+      if (duration.Contains(" "))
+      {
+        // When we implement non normalized durations we can call parseNonNormalizedDuration(duration)
+        throw new GedcomxDateException("Invalid Duration: Non normalized durations are not implemented yet");
+      }
+      else
+      {
+        ParseNormalizedDuration(duration);
+      }
+    }
 
-		/// <summary>
-		/// Parses the formal duration string and populates the results in this current instance.
-		/// </summary>
-		/// <param name="duration">The formal duration string to be parsed.</param>
-		/// <exception cref="GedcomxDateException">
-		/// Thrown if any of the current parsing expectations fail. A specific reason will be included at runtime.
-		/// </exception>
-		private void ParseNormalizedDuration(String duration)
-		{
-			String currentNum = "";
-			bool inTime = false;
-			HashSet<String> seen = new HashSet<String>();
-			List<String> valid = new List<string>() { "Y", "Mo", "D", "T", "H", "Mi", "S" };
+    /// <summary>
+    /// Parses the formal duration string and populates the results in this current instance.
+    /// </summary>
+    /// <param name="duration">The formal duration string to be parsed.</param>
+    /// <exception cref="GedcomxDateException">
+    /// Thrown if any of the current parsing expectations fail. A specific reason will be included at runtime.
+    /// </exception>
+    private void ParseNormalizedDuration(String duration)
+    {
+      String currentNum = "";
+      bool inTime = false;
+      HashSet<String> seen = new HashSet<String>();
+      List<String> valid = new List<string>() { "Y", "Mo", "D", "T", "H", "Mi", "S" };
 
-			foreach (char character in duration)
-			{
-				if (Char.IsDigit(character))
-				{
-					currentNum += character;
-					continue;
-				}
+      foreach (char character in duration)
+      {
+        if (Char.IsDigit(character))
+        {
+          currentNum += character;
+          continue;
+        }
 
-				switch (character)
-				{
-					case 'Y':
-						if (currentNum.Length < 1)
-						{
-							throw new GedcomxDateException("Invalid Duration: Invalid years");
-						}
-						if (seen.Contains("Y"))
-						{
-							throw new GedcomxDateException("Invalid Duration: Duplicate years");
-						}
-						if (!valid.Contains("Y"))
-						{
-							throw new GedcomxDateException("Invalid Duration: Years out of order");
-						}
-						this.years = Int32.Parse(currentNum);
-						seen.Add("Y");
-						valid = valid.Skip(valid.IndexOf("Y") + 1).ToList();
-						currentNum = "";
-						break;
-					case 'M':
-						if (inTime)
-						{
-							if (currentNum.Length < 1)
-							{
-								throw new GedcomxDateException("Invalid Duration: Invalid minutes");
-							}
-							if (seen.Contains("Mi"))
-							{
-								throw new GedcomxDateException("Invalid Duration: Duplicate minutes");
-							}
-							if (!valid.Contains("Mi"))
-							{
-								throw new GedcomxDateException("Invalid Duration: Minutes out of order");
-							}
-							this.minutes = Int32.Parse(currentNum);
-							seen.Add("Mi");
-							valid = valid.Skip(valid.IndexOf("Mi") + 1).ToList();
-							currentNum = "";
-						}
-						else
-						{
-							if (currentNum.Length < 1)
-							{
-								throw new GedcomxDateException("Invalid Duration: Invalid months");
-							}
-							if (seen.Contains("Mo"))
-							{
-								throw new GedcomxDateException("Invalid Duration: Duplicate months");
-							}
-							if (!valid.Contains("Mo"))
-							{
-								throw new GedcomxDateException("Invalid Duration: Months out of order");
-							}
-							this.months = Int32.Parse(currentNum);
-							seen.Add("Mo");
-							valid = valid.Skip(valid.IndexOf("Mo") + 1).ToList();
-							currentNum = "";
-						}
-						break;
-					case 'D':
-						if (currentNum.Length < 1)
-						{
-							throw new GedcomxDateException("Invalid Duration: Invalid days");
-						}
-						if (seen.Contains("D"))
-						{
-							throw new GedcomxDateException("Invalid Duration: Duplicate days");
-						}
-						if (!valid.Contains("D"))
-						{
-							throw new GedcomxDateException("Invalid Duration: Days out of order");
-						}
-						this.days = Int32.Parse(currentNum);
-						seen.Add("D");
-						valid = valid.Skip(valid.IndexOf("D") + 1).ToList();
-						currentNum = "";
-						break;
-					case 'H':
-						if (!inTime)
-						{
-							throw new GedcomxDateException("Invalid Duration: Missing T before hours");
-						}
-						if (currentNum.Length < 1)
-						{
-							throw new GedcomxDateException("Invalid Duration: Invalid hours");
-						}
-						if (seen.Contains("H"))
-						{
-							throw new GedcomxDateException("Invalid Duration: Duplicate hours");
-						}
-						if (!valid.Contains("H"))
-						{
-							throw new GedcomxDateException("Invalid Duration: Hours out of order");
-						}
-						this.hours = Int32.Parse(currentNum);
-						seen.Add("H");
-						valid = valid.Skip(valid.IndexOf("H") + 1).ToList();
-						currentNum = "";
-						break;
-					case 'S':
-						if (!inTime)
-						{
-							throw new GedcomxDateException("Invalid Duration: Missing T before seconds");
-						}
-						if (currentNum.Length < 1)
-						{
-							throw new GedcomxDateException("Invalid Duration: Invalid seconds");
-						}
-						if (seen.Contains("S"))
-						{
-							throw new GedcomxDateException("Invalid Duration: Duplicate seconds");
-						}
-						// You cannot have seconds out of order because it's last
-						this.seconds = Int32.Parse(currentNum);
-						seen.Add("S");
-						valid = new List<String>();
-						currentNum = "";
-						break;
-					case 'T':
-						if (seen.Contains("T"))
-						{
-							throw new GedcomxDateException("Invalid Duration: Duplicate T");
-						}
-						inTime = true;
-						seen.Add("T");
-						valid = valid.Skip(valid.IndexOf("T") + 1).ToList();
-						break;
-					default:
-						throw new GedcomxDateException("Invalid Duration: Unknown letter " + character);
-				}
-			}
+        switch (character)
+        {
+          case 'Y':
+            if (currentNum.Length < 1)
+            {
+              throw new GedcomxDateException("Invalid Duration: Invalid years");
+            }
+            if (seen.Contains("Y"))
+            {
+              throw new GedcomxDateException("Invalid Duration: Duplicate years");
+            }
+            if (!valid.Contains("Y"))
+            {
+              throw new GedcomxDateException("Invalid Duration: Years out of order");
+            }
+            this.years = Int32.Parse(currentNum);
+            seen.Add("Y");
+            valid = valid.Skip(valid.IndexOf("Y") + 1).ToList();
+            currentNum = "";
+            break;
+          case 'M':
+            if (inTime)
+            {
+              if (currentNum.Length < 1)
+              {
+                throw new GedcomxDateException("Invalid Duration: Invalid minutes");
+              }
+              if (seen.Contains("Mi"))
+              {
+                throw new GedcomxDateException("Invalid Duration: Duplicate minutes");
+              }
+              if (!valid.Contains("Mi"))
+              {
+                throw new GedcomxDateException("Invalid Duration: Minutes out of order");
+              }
+              this.minutes = Int32.Parse(currentNum);
+              seen.Add("Mi");
+              valid = valid.Skip(valid.IndexOf("Mi") + 1).ToList();
+              currentNum = "";
+            }
+            else
+            {
+              if (currentNum.Length < 1)
+              {
+                throw new GedcomxDateException("Invalid Duration: Invalid months");
+              }
+              if (seen.Contains("Mo"))
+              {
+                throw new GedcomxDateException("Invalid Duration: Duplicate months");
+              }
+              if (!valid.Contains("Mo"))
+              {
+                throw new GedcomxDateException("Invalid Duration: Months out of order");
+              }
+              this.months = Int32.Parse(currentNum);
+              seen.Add("Mo");
+              valid = valid.Skip(valid.IndexOf("Mo") + 1).ToList();
+              currentNum = "";
+            }
+            break;
+          case 'D':
+            if (currentNum.Length < 1)
+            {
+              throw new GedcomxDateException("Invalid Duration: Invalid days");
+            }
+            if (seen.Contains("D"))
+            {
+              throw new GedcomxDateException("Invalid Duration: Duplicate days");
+            }
+            if (!valid.Contains("D"))
+            {
+              throw new GedcomxDateException("Invalid Duration: Days out of order");
+            }
+            this.days = Int32.Parse(currentNum);
+            seen.Add("D");
+            valid = valid.Skip(valid.IndexOf("D") + 1).ToList();
+            currentNum = "";
+            break;
+          case 'H':
+            if (!inTime)
+            {
+              throw new GedcomxDateException("Invalid Duration: Missing T before hours");
+            }
+            if (currentNum.Length < 1)
+            {
+              throw new GedcomxDateException("Invalid Duration: Invalid hours");
+            }
+            if (seen.Contains("H"))
+            {
+              throw new GedcomxDateException("Invalid Duration: Duplicate hours");
+            }
+            if (!valid.Contains("H"))
+            {
+              throw new GedcomxDateException("Invalid Duration: Hours out of order");
+            }
+            this.hours = Int32.Parse(currentNum);
+            seen.Add("H");
+            valid = valid.Skip(valid.IndexOf("H") + 1).ToList();
+            currentNum = "";
+            break;
+          case 'S':
+            if (!inTime)
+            {
+              throw new GedcomxDateException("Invalid Duration: Missing T before seconds");
+            }
+            if (currentNum.Length < 1)
+            {
+              throw new GedcomxDateException("Invalid Duration: Invalid seconds");
+            }
+            if (seen.Contains("S"))
+            {
+              throw new GedcomxDateException("Invalid Duration: Duplicate seconds");
+            }
+            // You cannot have seconds out of order because it's last
+            this.seconds = Int32.Parse(currentNum);
+            seen.Add("S");
+            valid = new List<String>();
+            currentNum = "";
+            break;
+          case 'T':
+            if (seen.Contains("T"))
+            {
+              throw new GedcomxDateException("Invalid Duration: Duplicate T");
+            }
+            inTime = true;
+            seen.Add("T");
+            valid = valid.Skip(valid.IndexOf("T") + 1).ToList();
+            break;
+          default:
+            throw new GedcomxDateException("Invalid Duration: Unknown letter " + character);
+        }
+      }
 
-			// If there is any leftover we have an invalid duration
-			if (!currentNum.Equals(""))
-			{
-				throw new GedcomxDateException("Invalid Duration: No letter after " + currentNum);
-			}
+      // If there is any leftover we have an invalid duration
+      if (!currentNum.Equals(""))
+      {
+        throw new GedcomxDateException("Invalid Duration: No letter after " + currentNum);
+      }
 
-		}
+    }
 
-		/// <summary>
-		/// Gets the type of GEDCOM X date. This property always returns APPROXIMATE for this instance.
-		/// </summary>
-		/// <value>
-		/// The type of GEDCOM X date.
-		/// </value>
-		public override GedcomxDateType Type
-		{
-			get
-			{
-				return GedcomxDateType.DURATION;
-			}
-		}
+    /// <summary>
+    /// Gets the type of GEDCOM X date. This property always returns APPROXIMATE for this instance.
+    /// </summary>
+    /// <value>
+    /// The type of GEDCOM X date.
+    /// </value>
+    public override GedcomxDateType Type
+    {
+      get
+      {
+        return GedcomxDateType.DURATION;
+      }
+    }
 
-		/// <summary>
-		/// Determines whether this date is approximate.  This method always returns <c>false</c> for this instance.
-		/// </summary>
-		/// <value>
-		///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-		/// </value>
-		public override bool IsApproximate
-		{
-			get
-			{
-				return false;
-			}
-		}
+    /// <summary>
+    /// Determines whether this date is approximate.  This method always returns <c>false</c> for this instance.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+    /// </value>
+    public override bool IsApproximate
+    {
+      get
+      {
+        return false;
+      }
+    }
 
-		/// <summary>
-		/// The formal representation of this duration.
-		/// </summary>
-		/// <value>
-		/// The formal representation of this duration.
-		/// </value>
-		public override String FormalString
-		{
-			get
-			{
-				StringBuilder duration = new StringBuilder("P");
+    /// <summary>
+    /// The formal representation of this duration.
+    /// </summary>
+    /// <value>
+    /// The formal representation of this duration.
+    /// </value>
+    public override String FormalString
+    {
+      get
+      {
+        StringBuilder duration = new StringBuilder("P");
 
-				if (years != null)
-				{
-					duration.Append(years).Append('Y');
-				}
+        if (years != null)
+        {
+          duration.Append(years).Append('Y');
+        }
 
-				if (months != null)
-				{
-					duration.Append(months).Append('M');
-				}
+        if (months != null)
+        {
+          duration.Append(months).Append('M');
+        }
 
-				if (days != null)
-				{
-					duration.Append(days).Append('D');
-				}
+        if (days != null)
+        {
+          duration.Append(days).Append('D');
+        }
 
-				if (hours != null || minutes != null || seconds != null)
-				{
-					duration.Append('T');
+        if (hours != null || minutes != null || seconds != null)
+        {
+          duration.Append('T');
 
-					if (hours != null)
-					{
-						duration.Append(hours).Append('H');
-					}
+          if (hours != null)
+          {
+            duration.Append(hours).Append('H');
+          }
 
-					if (minutes != null)
-					{
-						duration.Append(minutes).Append('M');
-					}
+          if (minutes != null)
+          {
+            duration.Append(minutes).Append('M');
+          }
 
-					if (seconds != null)
-					{
-						duration.Append(seconds).Append('S');
-					}
-				}
+          if (seconds != null)
+          {
+            duration.Append(seconds).Append('S');
+          }
+        }
 
-				return duration.ToString();
-			}
-		}
+        return duration.ToString();
+      }
+    }
 
-		/// <summary>
-		/// Gets the years of the current duration if applicable.
-		/// </summary>
-		/// <value>
-		/// The years of the current duration if applicable.
-		/// </value>
-		public Int32? Years
-		{
-			get
-			{
-				return years;
-			}
-		}
+    /// <summary>
+    /// Gets the years of the current duration if applicable.
+    /// </summary>
+    /// <value>
+    /// The years of the current duration if applicable.
+    /// </value>
+    public Int32? Years
+    {
+      get
+      {
+        return years;
+      }
+    }
 
-		/// <summary>
-		/// Gets the months of the current duration if applicable.
-		/// </summary>
-		/// <value>
-		/// The months of the current duration if applicable.
-		/// </value>
-		public Int32? Months
-		{
-			get
-			{
-				return months;
-			}
-		}
+    /// <summary>
+    /// Gets the months of the current duration if applicable.
+    /// </summary>
+    /// <value>
+    /// The months of the current duration if applicable.
+    /// </value>
+    public Int32? Months
+    {
+      get
+      {
+        return months;
+      }
+    }
 
-		/// <summary>
-		/// Gets the days of the current duration if applicable.
-		/// </summary>
-		/// <value>
-		/// The days of the current duration if applicable.
-		/// </value>
-		public Int32? Days
-		{
-			get
-			{
-				return days;
-			}
-		}
+    /// <summary>
+    /// Gets the days of the current duration if applicable.
+    /// </summary>
+    /// <value>
+    /// The days of the current duration if applicable.
+    /// </value>
+    public Int32? Days
+    {
+      get
+      {
+        return days;
+      }
+    }
 
-		/// <summary>
-		/// Gets the hours of the current duration if applicable.
-		/// </summary>
-		/// <value>
-		/// The hours of the current duration if applicable.
-		/// </value>
-		public Int32? Hours
-		{
-			get
-			{
-				return hours;
-			}
-		}
+    /// <summary>
+    /// Gets the hours of the current duration if applicable.
+    /// </summary>
+    /// <value>
+    /// The hours of the current duration if applicable.
+    /// </value>
+    public Int32? Hours
+    {
+      get
+      {
+        return hours;
+      }
+    }
 
-		/// <summary>
-		/// Gets the minutes of the current duration if applicable.
-		/// </summary>
-		/// <value>
-		/// The minutes of the current duration if applicable.
-		/// </value>
-		public Int32? Minutes
-		{
-			get
-			{
-				return minutes;
-			}
-		}
+    /// <summary>
+    /// Gets the minutes of the current duration if applicable.
+    /// </summary>
+    /// <value>
+    /// The minutes of the current duration if applicable.
+    /// </value>
+    public Int32? Minutes
+    {
+      get
+      {
+        return minutes;
+      }
+    }
 
-		/// <summary>
-		/// Gets the seconds of the current duration if applicable.
-		/// </summary>
-		/// <value>
-		/// The seconds of the current duration if applicable.
-		/// </value>
-		public Int32? Seconds
-		{
-			get
-			{
-				return seconds;
-			}
-		}
-	}
+    /// <summary>
+    /// Gets the seconds of the current duration if applicable.
+    /// </summary>
+    /// <value>
+    /// The seconds of the current duration if applicable.
+    /// </value>
+    public Int32? Seconds
+    {
+      get
+      {
+        return seconds;
+      }
+    }
+  }
 }

--- a/GEDCOM X Date/GedcomxDateDuration.cs
+++ b/GEDCOM X Date/GedcomxDateDuration.cs
@@ -5,375 +5,381 @@ using System.Text;
 
 namespace Gedcomx.Date
 {
+  /// <summary>
+  /// Represents a GEDCOM X date span, measured from years to seconds.
+  /// </summary>
+  public class GedcomxDateDuration : GedcomxDate
+  {
+    private Int32? years = null;
+    private Int32? months = null;
+    private Int32? days = null;
+    private Int32? hours = null;
+    private Int32? minutes = null;
+    private Int32? seconds = null;
+
     /// <summary>
-    /// Represents a GEDCOM X date span, measured from years to seconds.
+    /// Initializes a new instance of the <see cref="GedcomxDateDuration"/> class.
     /// </summary>
-    public class GedcomxDateDuration : GedcomxDate
+    /// <param name="str">The formal duration string that describes a GEDCOM X duration.</param>
+    /// <exception cref="GedcomxDateException">
+    /// Thrown if the formal string is null, empty, or does not begin with 'P'.
+    /// or
+    /// Thrown if the formal string does not have a duration specified (the string after 'P').
+    /// or
+    /// Thrown if the formal string is a 5.3.2 non-normalized date (these are not yet implemented).
+    /// </exception>
+    public GedcomxDateDuration(String str)
     {
-        private Int32? years = null;
-        private Int32? months = null;
-        private Int32? days = null;
-        private Int32? hours = null;
-        private Int32? minutes = null;
-        private Int32? seconds = null;
+      // Durations must start with P
+      if (str == null || str.Length < 1 || str[0] != 'P')
+      {
+        throw new GedcomxDateException("Invalid Duration: Must start with P");
+      }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GedcomxDateDuration"/> class.
-        /// </summary>
-        /// <param name="str">The formal duration string that describes a GEDCOM X duration.</param>
-        /// <exception cref="GedcomxDateException">
-        /// Thrown if the formal string is null, empty, or does not begin with 'P'.
-        /// or
-        /// Thrown if the formal string does not have a duration specified (the string after 'P').
-        /// or
-        /// Thrown if the formal string is a 5.3.2 non-normalized date (these are not yet implemented).
-        /// </exception>
-        public GedcomxDateDuration(String str)
+      String duration = str.Substring(1);
+
+      if (duration.Length < 1)
+      {
+        throw new GedcomxDateException("Invalid Duration: You must have a duration value");
+      }
+
+      // 5.3.2 allows for NON normalized durations
+      // We assume that if there is a space, it is non-normalized
+      if (duration.Contains(" "))
+      {
+        // When we implement non normalized durations we can call parseNonNormalizedDuration(duration)
+        throw new GedcomxDateException("Invalid Duration: Non normalized durations are not implemented yet");
+      }
+      else
+      {
+        ParseNormalizedDuration(duration);
+      }
+    }
+
+    /// <summary>
+    /// Parses the formal duration string and populates the results in this current instance.
+    /// </summary>
+    /// <param name="duration">The formal duration string to be parsed.</param>
+    /// <exception cref="GedcomxDateException">
+    /// Thrown if any of the current parsing expectations fail. A specific reason will be included at runtime.
+    /// </exception>
+    private void ParseNormalizedDuration(String duration)
+    {
+      String currentNum = "";
+      bool inTime = false;
+      HashSet<String> seen = new HashSet<String>();
+      List<String> valid = new List<string>() { "Y", "Mo", "D", "T", "H", "Mi", "S" };
+
+      foreach (char character in duration)
+      {
+        if (Char.IsDigit(character))
         {
-            // Durations must start with P
-            if (str == null || str.Length < 1 || str[0] != 'P')
+          currentNum += character;
+          continue;
+        }
+
+        switch (character)
+        {
+          case 'Y':
+            if (currentNum.Length < 1)
             {
-                throw new GedcomxDateException("Invalid Duration: Must start with P");
+              throw new GedcomxDateException("Invalid Duration: Invalid years");
             }
-
-            String duration = str.Substring(1);
-
-            if (duration.Length < 1)
+            if (seen.Contains("Y"))
             {
-                throw new GedcomxDateException("Invalid Duration: You must have a duration value");
+              throw new GedcomxDateException("Invalid Duration: Duplicate years");
             }
-
-            // 5.3.2 allows for NON normalized durations
-            // We assume that if there is a space, it is non-normalized
-            if (duration.Contains(" "))
+            if (!valid.Contains("Y"))
             {
-                // When we implement non normalized durations we can call parseNonNormalizedDuration(duration)
-                throw new GedcomxDateException("Invalid Duration: Non normalized durations are not implemented yet");
+              throw new GedcomxDateException("Invalid Duration: Years out of order");
+            }
+            this.years = Int32.Parse(currentNum);
+            seen.Add("Y");
+            valid = valid.Skip(valid.IndexOf("Y") + 1).ToList();
+            currentNum = "";
+            break;
+          case 'M':
+            if (inTime)
+            {
+              if (currentNum.Length < 1)
+              {
+                throw new GedcomxDateException("Invalid Duration: Invalid minutes");
+              }
+              if (seen.Contains("Mi"))
+              {
+                throw new GedcomxDateException("Invalid Duration: Duplicate minutes");
+              }
+              if (!valid.Contains("Mi"))
+              {
+                throw new GedcomxDateException("Invalid Duration: Minutes out of order");
+              }
+              this.minutes = Int32.Parse(currentNum);
+              seen.Add("Mi");
+              valid = valid.Skip(valid.IndexOf("Mi") + 1).ToList();
+              currentNum = "";
             }
             else
             {
-                ParseNormalizedDuration(duration);
+              if (currentNum.Length < 1)
+              {
+                throw new GedcomxDateException("Invalid Duration: Invalid months");
+              }
+              if (seen.Contains("Mo"))
+              {
+                throw new GedcomxDateException("Invalid Duration: Duplicate months");
+              }
+              if (!valid.Contains("Mo"))
+              {
+                throw new GedcomxDateException("Invalid Duration: Months out of order");
+              }
+              this.months = Int32.Parse(currentNum);
+              seen.Add("Mo");
+              valid = valid.Skip(valid.IndexOf("Mo") + 1).ToList();
+              currentNum = "";
             }
+            break;
+          case 'D':
+            if (currentNum.Length < 1)
+            {
+              throw new GedcomxDateException("Invalid Duration: Invalid days");
+            }
+            if (seen.Contains("D"))
+            {
+              throw new GedcomxDateException("Invalid Duration: Duplicate days");
+            }
+            if (!valid.Contains("D"))
+            {
+              throw new GedcomxDateException("Invalid Duration: Days out of order");
+            }
+            this.days = Int32.Parse(currentNum);
+            seen.Add("D");
+            valid = valid.Skip(valid.IndexOf("D") + 1).ToList();
+            currentNum = "";
+            break;
+          case 'H':
+            if (!inTime)
+            {
+              throw new GedcomxDateException("Invalid Duration: Missing T before hours");
+            }
+            if (currentNum.Length < 1)
+            {
+              throw new GedcomxDateException("Invalid Duration: Invalid hours");
+            }
+            if (seen.Contains("H"))
+            {
+              throw new GedcomxDateException("Invalid Duration: Duplicate hours");
+            }
+            if (!valid.Contains("H"))
+            {
+              throw new GedcomxDateException("Invalid Duration: Hours out of order");
+            }
+            this.hours = Int32.Parse(currentNum);
+            seen.Add("H");
+            valid = valid.Skip(valid.IndexOf("H") + 1).ToList();
+            currentNum = "";
+            break;
+          case 'S':
+            if (!inTime)
+            {
+              throw new GedcomxDateException("Invalid Duration: Missing T before seconds");
+            }
+            if (currentNum.Length < 1)
+            {
+              throw new GedcomxDateException("Invalid Duration: Invalid seconds");
+            }
+            if (seen.Contains("S"))
+            {
+              throw new GedcomxDateException("Invalid Duration: Duplicate seconds");
+            }
+            // You cannot have seconds out of order because it's last
+            this.seconds = Int32.Parse(currentNum);
+            seen.Add("S");
+            valid = new List<String>();
+            currentNum = "";
+            break;
+          case 'T':
+            if (seen.Contains("T"))
+            {
+              throw new GedcomxDateException("Invalid Duration: Duplicate T");
+            }
+            inTime = true;
+            seen.Add("T");
+            valid = valid.Skip(valid.IndexOf("T") + 1).ToList();
+            break;
+          default:
+            throw new GedcomxDateException("Invalid Duration: Unknown letter " + character);
         }
+      }
 
-        /// <summary>
-        /// Parses the formal duration string and populates the results in this current instance.
-        /// </summary>
-        /// <param name="duration">The formal duration string to be parsed.</param>
-        /// <exception cref="GedcomxDateException">
-        /// Thrown if any of the current parsing expectations fail. A specific reason will be included at runtime.
-        /// </exception>
-        private void ParseNormalizedDuration(String duration)
-        {
-            String currentNum = "";
-            bool inTime = false;
-            HashSet<String> seen = new HashSet<String>();
-            List<String> valid = new List<string>() { "Y", "Mo", "D", "T", "H", "Mi", "S" };
+      // If there is any leftover we have an invalid duration
+      if (!currentNum.Equals(""))
+      {
+        throw new GedcomxDateException("Invalid Duration: No letter after " + currentNum);
+      }
 
-            foreach (char character in duration)
-            {
-                if (Char.IsDigit(character))
-                {
-                    currentNum += character;
-                    continue;
-                }
-
-                switch (character)
-                {
-                    case 'Y':
-                        if (currentNum.Length < 1)
-                        {
-                            throw new GedcomxDateException("Invalid Duration: Invalid years");
-                        }
-                        if (seen.Contains("Y"))
-                        {
-                            throw new GedcomxDateException("Invalid Duration: Duplicate years");
-                        }
-                        if (!valid.Contains("Y"))
-                        {
-                            throw new GedcomxDateException("Invalid Duration: Years out of order");
-                        }
-                        this.years = Int32.Parse(currentNum);
-                        seen.Add("Y");
-                        valid = valid.Skip(valid.IndexOf("Y") + 1).ToList();
-                        currentNum = "";
-                        break;
-                    case 'M':
-                        if (inTime)
-                        {
-                            if (currentNum.Length < 1)
-                            {
-                                throw new GedcomxDateException("Invalid Duration: Invalid minutes");
-                            }
-                            if (seen.Contains("Mi"))
-                            {
-                                throw new GedcomxDateException("Invalid Duration: Duplicate minutes");
-                            }
-                            if (!valid.Contains("Mi"))
-                            {
-                                throw new GedcomxDateException("Invalid Duration: Minutes out of order");
-                            }
-                            this.minutes = Int32.Parse(currentNum);
-                            seen.Add("Mi");
-                            valid = valid.Skip(valid.IndexOf("Mi") + 1).ToList();
-                            currentNum = "";
-                        }
-                        else
-                        {
-                            if (currentNum.Length < 1)
-                            {
-                                throw new GedcomxDateException("Invalid Duration: Invalid months");
-                            }
-                            if (seen.Contains("Mo"))
-                            {
-                                throw new GedcomxDateException("Invalid Duration: Duplicate months");
-                            }
-                            if (!valid.Contains("Mo"))
-                            {
-                                throw new GedcomxDateException("Invalid Duration: Months out of order");
-                            }
-                            this.months = Int32.Parse(currentNum);
-                            seen.Add("Mo");
-                            valid = valid.Skip(valid.IndexOf("Mo") + 1).ToList();
-                            currentNum = "";
-                        }
-                        break;
-                    case 'D':
-                        if (currentNum.Length < 1)
-                        {
-                            throw new GedcomxDateException("Invalid Duration: Invalid days");
-                        }
-                        if (seen.Contains("D"))
-                        {
-                            throw new GedcomxDateException("Invalid Duration: Duplicate days");
-                        }
-                        if (!valid.Contains("D"))
-                        {
-                            throw new GedcomxDateException("Invalid Duration: Days out of order");
-                        }
-                        this.days = Int32.Parse(currentNum);
-                        seen.Add("D");
-                        valid = valid.Skip(valid.IndexOf("D") + 1).ToList();
-                        currentNum = "";
-                        break;
-                    case 'H':
-                        if (!inTime)
-                        {
-                            throw new GedcomxDateException("Invalid Duration: Missing T before hours");
-                        }
-                        if (currentNum.Length < 1)
-                        {
-                            throw new GedcomxDateException("Invalid Duration: Invalid hours");
-                        }
-                        if (seen.Contains("H"))
-                        {
-                            throw new GedcomxDateException("Invalid Duration: Duplicate hours");
-                        }
-                        if (!valid.Contains("H"))
-                        {
-                            throw new GedcomxDateException("Invalid Duration: Hours out of order");
-                        }
-                        this.hours = Int32.Parse(currentNum);
-                        seen.Add("H");
-                        valid = valid.Skip(valid.IndexOf("H") + 1).ToList();
-                        currentNum = "";
-                        break;
-                    case 'S':
-                        if (!inTime)
-                        {
-                            throw new GedcomxDateException("Invalid Duration: Missing T before seconds");
-                        }
-                        if (currentNum.Length < 1)
-                        {
-                            throw new GedcomxDateException("Invalid Duration: Invalid seconds");
-                        }
-                        if (seen.Contains("S"))
-                        {
-                            throw new GedcomxDateException("Invalid Duration: Duplicate seconds");
-                        }
-                        // You cannot have seconds out of order because it's last
-                        this.seconds = Int32.Parse(currentNum);
-                        seen.Add("S");
-                        valid = new List<String>();
-                        currentNum = "";
-                        break;
-                    case 'T':
-                        if (seen.Contains("T"))
-                        {
-                            throw new GedcomxDateException("Invalid Duration: Duplicate T");
-                        }
-                        inTime = true;
-                        seen.Add("T");
-                        valid = valid.Skip(valid.IndexOf("T") + 1).ToList();
-                        break;
-                    default:
-                        throw new GedcomxDateException("Invalid Duration: Unknown letter " + character);
-                }
-            }
-
-            // If there is any leftover we have an invalid duration
-            if (!currentNum.Equals(""))
-            {
-                throw new GedcomxDateException("Invalid Duration: No letter after " + currentNum);
-            }
-
-        }
-
-        /// <summary>
-        /// Gets the type of GEDCOM X date. This property always returns APPROXIMATE for this instance.
-        /// </summary>
-        /// <value>
-        /// The type of GEDCOM X date.
-        /// </value>
-        public override GedcomxDateType Type
-        {
-            get
-            {
-                return GedcomxDateType.DURATION;
-            }
-        }
-
-        /// <summary>
-        /// Determines whether this date is approximate.  This method always returns <c>false</c> for this instance.
-        /// </summary>
-        /// <returns>
-        ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-        /// </returns>
-        public override bool IsApproximate()
-        {
-            return false;
-        }
-
-        /// <summary>
-        /// The formal representation of this duration.
-        /// </summary>
-        /// <returns>
-        /// The formal representation of this duration.
-        /// </returns>
-        public override String ToFormalString()
-        {
-            StringBuilder duration = new StringBuilder("P");
-
-            if (years != null)
-            {
-                duration.Append(years).Append('Y');
-            }
-
-            if (months != null)
-            {
-                duration.Append(months).Append('M');
-            }
-
-            if (days != null)
-            {
-                duration.Append(days).Append('D');
-            }
-
-            if (hours != null || minutes != null || seconds != null)
-            {
-                duration.Append('T');
-
-                if (hours != null)
-                {
-                    duration.Append(hours).Append('H');
-                }
-
-                if (minutes != null)
-                {
-                    duration.Append(minutes).Append('M');
-                }
-
-                if (seconds != null)
-                {
-                    duration.Append(seconds).Append('S');
-                }
-            }
-
-            return duration.ToString();
-        }
-
-        /// <summary>
-        /// Gets the years of the current duration if applicable.
-        /// </summary>
-        /// <value>
-        /// The years of the current duration if applicable.
-        /// </value>
-        public Int32? Years
-        {
-            get
-            {
-                return years;
-            }
-        }
-
-        /// <summary>
-        /// Gets the months of the current duration if applicable.
-        /// </summary>
-        /// <value>
-        /// The months of the current duration if applicable.
-        /// </value>
-        public Int32? Months
-        {
-            get
-            {
-                return months;
-            }
-        }
-
-        /// <summary>
-        /// Gets the days of the current duration if applicable.
-        /// </summary>
-        /// <value>
-        /// The days of the current duration if applicable.
-        /// </value>
-        public Int32? Days
-        {
-            get
-            {
-                return days;
-            }
-        }
-
-        /// <summary>
-        /// Gets the hours of the current duration if applicable.
-        /// </summary>
-        /// <value>
-        /// The hours of the current duration if applicable.
-        /// </value>
-        public Int32? Hours
-        {
-            get
-            {
-                return hours;
-            }
-        }
-
-        /// <summary>
-        /// Gets the minutes of the current duration if applicable.
-        /// </summary>
-        /// <value>
-        /// The minutes of the current duration if applicable.
-        /// </value>
-        public Int32? Minutes
-        {
-            get
-            {
-                return minutes;
-            }
-        }
-
-        /// <summary>
-        /// Gets the seconds of the current duration if applicable.
-        /// </summary>
-        /// <value>
-        /// The seconds of the current duration if applicable.
-        /// </value>
-        public Int32? Seconds
-        {
-            get
-            {
-                return seconds;
-            }
-        }
     }
+
+    /// <summary>
+    /// Gets the type of GEDCOM X date. This property always returns APPROXIMATE for this instance.
+    /// </summary>
+    /// <value>
+    /// The type of GEDCOM X date.
+    /// </value>
+    public override GedcomxDateType Type
+    {
+      get
+      {
+        return GedcomxDateType.DURATION;
+      }
+    }
+
+    /// <summary>
+    /// Determines whether this date is approximate.  This method always returns <c>false</c> for this instance.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+    /// </value>
+    public override bool IsApproximate
+    {
+      get
+      {
+        return false;
+      }
+    }
+
+    /// <summary>
+    /// The formal representation of this duration.
+    /// </summary>
+    /// <value>
+    /// The formal representation of this duration.
+    /// </value>
+    public override String FormalString
+    {
+      get
+      {
+        StringBuilder duration = new StringBuilder("P");
+
+        if (years != null)
+        {
+          duration.Append(years).Append('Y');
+        }
+
+        if (months != null)
+        {
+          duration.Append(months).Append('M');
+        }
+
+        if (days != null)
+        {
+          duration.Append(days).Append('D');
+        }
+
+        if (hours != null || minutes != null || seconds != null)
+        {
+          duration.Append('T');
+
+          if (hours != null)
+          {
+            duration.Append(hours).Append('H');
+          }
+
+          if (minutes != null)
+          {
+            duration.Append(minutes).Append('M');
+          }
+
+          if (seconds != null)
+          {
+            duration.Append(seconds).Append('S');
+          }
+        }
+
+        return duration.ToString();
+      }
+    }
+
+    /// <summary>
+    /// Gets the years of the current duration if applicable.
+    /// </summary>
+    /// <value>
+    /// The years of the current duration if applicable.
+    /// </value>
+    public Int32? Years
+    {
+      get
+      {
+        return years;
+      }
+    }
+
+    /// <summary>
+    /// Gets the months of the current duration if applicable.
+    /// </summary>
+    /// <value>
+    /// The months of the current duration if applicable.
+    /// </value>
+    public Int32? Months
+    {
+      get
+      {
+        return months;
+      }
+    }
+
+    /// <summary>
+    /// Gets the days of the current duration if applicable.
+    /// </summary>
+    /// <value>
+    /// The days of the current duration if applicable.
+    /// </value>
+    public Int32? Days
+    {
+      get
+      {
+        return days;
+      }
+    }
+
+    /// <summary>
+    /// Gets the hours of the current duration if applicable.
+    /// </summary>
+    /// <value>
+    /// The hours of the current duration if applicable.
+    /// </value>
+    public Int32? Hours
+    {
+      get
+      {
+        return hours;
+      }
+    }
+
+    /// <summary>
+    /// Gets the minutes of the current duration if applicable.
+    /// </summary>
+    /// <value>
+    /// The minutes of the current duration if applicable.
+    /// </value>
+    public Int32? Minutes
+    {
+      get
+      {
+        return minutes;
+      }
+    }
+
+    /// <summary>
+    /// Gets the seconds of the current duration if applicable.
+    /// </summary>
+    /// <value>
+    /// The seconds of the current duration if applicable.
+    /// </value>
+    public Int32? Seconds
+    {
+      get
+      {
+        return seconds;
+      }
+    }
+  }
 }

--- a/GEDCOM X Date/GedcomxDateDuration.cs
+++ b/GEDCOM X Date/GedcomxDateDuration.cs
@@ -5,381 +5,381 @@ using System.Text;
 
 namespace Gedcomx.Date
 {
-  /// <summary>
-  /// Represents a GEDCOM X date span, measured from years to seconds.
-  /// </summary>
-  public class GedcomxDateDuration : GedcomxDate
-  {
-    private Int32? years = null;
-    private Int32? months = null;
-    private Int32? days = null;
-    private Int32? hours = null;
-    private Int32? minutes = null;
-    private Int32? seconds = null;
+	/// <summary>
+	/// Represents a GEDCOM X date span, measured from years to seconds.
+	/// </summary>
+	public class GedcomxDateDuration : GedcomxDate
+	{
+		private Int32? years = null;
+		private Int32? months = null;
+		private Int32? days = null;
+		private Int32? hours = null;
+		private Int32? minutes = null;
+		private Int32? seconds = null;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="GedcomxDateDuration"/> class.
-    /// </summary>
-    /// <param name="str">The formal duration string that describes a GEDCOM X duration.</param>
-    /// <exception cref="GedcomxDateException">
-    /// Thrown if the formal string is null, empty, or does not begin with 'P'.
-    /// or
-    /// Thrown if the formal string does not have a duration specified (the string after 'P').
-    /// or
-    /// Thrown if the formal string is a 5.3.2 non-normalized date (these are not yet implemented).
-    /// </exception>
-    public GedcomxDateDuration(String str)
-    {
-      // Durations must start with P
-      if (str == null || str.Length < 1 || str[0] != 'P')
-      {
-        throw new GedcomxDateException("Invalid Duration: Must start with P");
-      }
+		/// <summary>
+		/// Initializes a new instance of the <see cref="GedcomxDateDuration"/> class.
+		/// </summary>
+		/// <param name="str">The formal duration string that describes a GEDCOM X duration.</param>
+		/// <exception cref="GedcomxDateException">
+		/// Thrown if the formal string is null, empty, or does not begin with 'P'.
+		/// or
+		/// Thrown if the formal string does not have a duration specified (the string after 'P').
+		/// or
+		/// Thrown if the formal string is a 5.3.2 non-normalized date (these are not yet implemented).
+		/// </exception>
+		public GedcomxDateDuration(String str)
+		{
+			// Durations must start with P
+			if (str == null || str.Length < 1 || str[0] != 'P')
+			{
+				throw new GedcomxDateException("Invalid Duration: Must start with P");
+			}
 
-      String duration = str.Substring(1);
+			String duration = str.Substring(1);
 
-      if (duration.Length < 1)
-      {
-        throw new GedcomxDateException("Invalid Duration: You must have a duration value");
-      }
+			if (duration.Length < 1)
+			{
+				throw new GedcomxDateException("Invalid Duration: You must have a duration value");
+			}
 
-      // 5.3.2 allows for NON normalized durations
-      // We assume that if there is a space, it is non-normalized
-      if (duration.Contains(" "))
-      {
-        // When we implement non normalized durations we can call parseNonNormalizedDuration(duration)
-        throw new GedcomxDateException("Invalid Duration: Non normalized durations are not implemented yet");
-      }
-      else
-      {
-        ParseNormalizedDuration(duration);
-      }
-    }
+			// 5.3.2 allows for NON normalized durations
+			// We assume that if there is a space, it is non-normalized
+			if (duration.Contains(" "))
+			{
+				// When we implement non normalized durations we can call parseNonNormalizedDuration(duration)
+				throw new GedcomxDateException("Invalid Duration: Non normalized durations are not implemented yet");
+			}
+			else
+			{
+				ParseNormalizedDuration(duration);
+			}
+		}
 
-    /// <summary>
-    /// Parses the formal duration string and populates the results in this current instance.
-    /// </summary>
-    /// <param name="duration">The formal duration string to be parsed.</param>
-    /// <exception cref="GedcomxDateException">
-    /// Thrown if any of the current parsing expectations fail. A specific reason will be included at runtime.
-    /// </exception>
-    private void ParseNormalizedDuration(String duration)
-    {
-      String currentNum = "";
-      bool inTime = false;
-      HashSet<String> seen = new HashSet<String>();
-      List<String> valid = new List<string>() { "Y", "Mo", "D", "T", "H", "Mi", "S" };
+		/// <summary>
+		/// Parses the formal duration string and populates the results in this current instance.
+		/// </summary>
+		/// <param name="duration">The formal duration string to be parsed.</param>
+		/// <exception cref="GedcomxDateException">
+		/// Thrown if any of the current parsing expectations fail. A specific reason will be included at runtime.
+		/// </exception>
+		private void ParseNormalizedDuration(String duration)
+		{
+			String currentNum = "";
+			bool inTime = false;
+			HashSet<String> seen = new HashSet<String>();
+			List<String> valid = new List<string>() { "Y", "Mo", "D", "T", "H", "Mi", "S" };
 
-      foreach (char character in duration)
-      {
-        if (Char.IsDigit(character))
-        {
-          currentNum += character;
-          continue;
-        }
+			foreach (char character in duration)
+			{
+				if (Char.IsDigit(character))
+				{
+					currentNum += character;
+					continue;
+				}
 
-        switch (character)
-        {
-          case 'Y':
-            if (currentNum.Length < 1)
-            {
-              throw new GedcomxDateException("Invalid Duration: Invalid years");
-            }
-            if (seen.Contains("Y"))
-            {
-              throw new GedcomxDateException("Invalid Duration: Duplicate years");
-            }
-            if (!valid.Contains("Y"))
-            {
-              throw new GedcomxDateException("Invalid Duration: Years out of order");
-            }
-            this.years = Int32.Parse(currentNum);
-            seen.Add("Y");
-            valid = valid.Skip(valid.IndexOf("Y") + 1).ToList();
-            currentNum = "";
-            break;
-          case 'M':
-            if (inTime)
-            {
-              if (currentNum.Length < 1)
-              {
-                throw new GedcomxDateException("Invalid Duration: Invalid minutes");
-              }
-              if (seen.Contains("Mi"))
-              {
-                throw new GedcomxDateException("Invalid Duration: Duplicate minutes");
-              }
-              if (!valid.Contains("Mi"))
-              {
-                throw new GedcomxDateException("Invalid Duration: Minutes out of order");
-              }
-              this.minutes = Int32.Parse(currentNum);
-              seen.Add("Mi");
-              valid = valid.Skip(valid.IndexOf("Mi") + 1).ToList();
-              currentNum = "";
-            }
-            else
-            {
-              if (currentNum.Length < 1)
-              {
-                throw new GedcomxDateException("Invalid Duration: Invalid months");
-              }
-              if (seen.Contains("Mo"))
-              {
-                throw new GedcomxDateException("Invalid Duration: Duplicate months");
-              }
-              if (!valid.Contains("Mo"))
-              {
-                throw new GedcomxDateException("Invalid Duration: Months out of order");
-              }
-              this.months = Int32.Parse(currentNum);
-              seen.Add("Mo");
-              valid = valid.Skip(valid.IndexOf("Mo") + 1).ToList();
-              currentNum = "";
-            }
-            break;
-          case 'D':
-            if (currentNum.Length < 1)
-            {
-              throw new GedcomxDateException("Invalid Duration: Invalid days");
-            }
-            if (seen.Contains("D"))
-            {
-              throw new GedcomxDateException("Invalid Duration: Duplicate days");
-            }
-            if (!valid.Contains("D"))
-            {
-              throw new GedcomxDateException("Invalid Duration: Days out of order");
-            }
-            this.days = Int32.Parse(currentNum);
-            seen.Add("D");
-            valid = valid.Skip(valid.IndexOf("D") + 1).ToList();
-            currentNum = "";
-            break;
-          case 'H':
-            if (!inTime)
-            {
-              throw new GedcomxDateException("Invalid Duration: Missing T before hours");
-            }
-            if (currentNum.Length < 1)
-            {
-              throw new GedcomxDateException("Invalid Duration: Invalid hours");
-            }
-            if (seen.Contains("H"))
-            {
-              throw new GedcomxDateException("Invalid Duration: Duplicate hours");
-            }
-            if (!valid.Contains("H"))
-            {
-              throw new GedcomxDateException("Invalid Duration: Hours out of order");
-            }
-            this.hours = Int32.Parse(currentNum);
-            seen.Add("H");
-            valid = valid.Skip(valid.IndexOf("H") + 1).ToList();
-            currentNum = "";
-            break;
-          case 'S':
-            if (!inTime)
-            {
-              throw new GedcomxDateException("Invalid Duration: Missing T before seconds");
-            }
-            if (currentNum.Length < 1)
-            {
-              throw new GedcomxDateException("Invalid Duration: Invalid seconds");
-            }
-            if (seen.Contains("S"))
-            {
-              throw new GedcomxDateException("Invalid Duration: Duplicate seconds");
-            }
-            // You cannot have seconds out of order because it's last
-            this.seconds = Int32.Parse(currentNum);
-            seen.Add("S");
-            valid = new List<String>();
-            currentNum = "";
-            break;
-          case 'T':
-            if (seen.Contains("T"))
-            {
-              throw new GedcomxDateException("Invalid Duration: Duplicate T");
-            }
-            inTime = true;
-            seen.Add("T");
-            valid = valid.Skip(valid.IndexOf("T") + 1).ToList();
-            break;
-          default:
-            throw new GedcomxDateException("Invalid Duration: Unknown letter " + character);
-        }
-      }
+				switch (character)
+				{
+					case 'Y':
+						if (currentNum.Length < 1)
+						{
+							throw new GedcomxDateException("Invalid Duration: Invalid years");
+						}
+						if (seen.Contains("Y"))
+						{
+							throw new GedcomxDateException("Invalid Duration: Duplicate years");
+						}
+						if (!valid.Contains("Y"))
+						{
+							throw new GedcomxDateException("Invalid Duration: Years out of order");
+						}
+						this.years = Int32.Parse(currentNum);
+						seen.Add("Y");
+						valid = valid.Skip(valid.IndexOf("Y") + 1).ToList();
+						currentNum = "";
+						break;
+					case 'M':
+						if (inTime)
+						{
+							if (currentNum.Length < 1)
+							{
+								throw new GedcomxDateException("Invalid Duration: Invalid minutes");
+							}
+							if (seen.Contains("Mi"))
+							{
+								throw new GedcomxDateException("Invalid Duration: Duplicate minutes");
+							}
+							if (!valid.Contains("Mi"))
+							{
+								throw new GedcomxDateException("Invalid Duration: Minutes out of order");
+							}
+							this.minutes = Int32.Parse(currentNum);
+							seen.Add("Mi");
+							valid = valid.Skip(valid.IndexOf("Mi") + 1).ToList();
+							currentNum = "";
+						}
+						else
+						{
+							if (currentNum.Length < 1)
+							{
+								throw new GedcomxDateException("Invalid Duration: Invalid months");
+							}
+							if (seen.Contains("Mo"))
+							{
+								throw new GedcomxDateException("Invalid Duration: Duplicate months");
+							}
+							if (!valid.Contains("Mo"))
+							{
+								throw new GedcomxDateException("Invalid Duration: Months out of order");
+							}
+							this.months = Int32.Parse(currentNum);
+							seen.Add("Mo");
+							valid = valid.Skip(valid.IndexOf("Mo") + 1).ToList();
+							currentNum = "";
+						}
+						break;
+					case 'D':
+						if (currentNum.Length < 1)
+						{
+							throw new GedcomxDateException("Invalid Duration: Invalid days");
+						}
+						if (seen.Contains("D"))
+						{
+							throw new GedcomxDateException("Invalid Duration: Duplicate days");
+						}
+						if (!valid.Contains("D"))
+						{
+							throw new GedcomxDateException("Invalid Duration: Days out of order");
+						}
+						this.days = Int32.Parse(currentNum);
+						seen.Add("D");
+						valid = valid.Skip(valid.IndexOf("D") + 1).ToList();
+						currentNum = "";
+						break;
+					case 'H':
+						if (!inTime)
+						{
+							throw new GedcomxDateException("Invalid Duration: Missing T before hours");
+						}
+						if (currentNum.Length < 1)
+						{
+							throw new GedcomxDateException("Invalid Duration: Invalid hours");
+						}
+						if (seen.Contains("H"))
+						{
+							throw new GedcomxDateException("Invalid Duration: Duplicate hours");
+						}
+						if (!valid.Contains("H"))
+						{
+							throw new GedcomxDateException("Invalid Duration: Hours out of order");
+						}
+						this.hours = Int32.Parse(currentNum);
+						seen.Add("H");
+						valid = valid.Skip(valid.IndexOf("H") + 1).ToList();
+						currentNum = "";
+						break;
+					case 'S':
+						if (!inTime)
+						{
+							throw new GedcomxDateException("Invalid Duration: Missing T before seconds");
+						}
+						if (currentNum.Length < 1)
+						{
+							throw new GedcomxDateException("Invalid Duration: Invalid seconds");
+						}
+						if (seen.Contains("S"))
+						{
+							throw new GedcomxDateException("Invalid Duration: Duplicate seconds");
+						}
+						// You cannot have seconds out of order because it's last
+						this.seconds = Int32.Parse(currentNum);
+						seen.Add("S");
+						valid = new List<String>();
+						currentNum = "";
+						break;
+					case 'T':
+						if (seen.Contains("T"))
+						{
+							throw new GedcomxDateException("Invalid Duration: Duplicate T");
+						}
+						inTime = true;
+						seen.Add("T");
+						valid = valid.Skip(valid.IndexOf("T") + 1).ToList();
+						break;
+					default:
+						throw new GedcomxDateException("Invalid Duration: Unknown letter " + character);
+				}
+			}
 
-      // If there is any leftover we have an invalid duration
-      if (!currentNum.Equals(""))
-      {
-        throw new GedcomxDateException("Invalid Duration: No letter after " + currentNum);
-      }
+			// If there is any leftover we have an invalid duration
+			if (!currentNum.Equals(""))
+			{
+				throw new GedcomxDateException("Invalid Duration: No letter after " + currentNum);
+			}
 
-    }
+		}
 
-    /// <summary>
-    /// Gets the type of GEDCOM X date. This property always returns APPROXIMATE for this instance.
-    /// </summary>
-    /// <value>
-    /// The type of GEDCOM X date.
-    /// </value>
-    public override GedcomxDateType Type
-    {
-      get
-      {
-        return GedcomxDateType.DURATION;
-      }
-    }
+		/// <summary>
+		/// Gets the type of GEDCOM X date. This property always returns APPROXIMATE for this instance.
+		/// </summary>
+		/// <value>
+		/// The type of GEDCOM X date.
+		/// </value>
+		public override GedcomxDateType Type
+		{
+			get
+			{
+				return GedcomxDateType.DURATION;
+			}
+		}
 
-    /// <summary>
-    /// Determines whether this date is approximate.  This method always returns <c>false</c> for this instance.
-    /// </summary>
-    /// <value>
-    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-    /// </value>
-    public override bool IsApproximate
-    {
-      get
-      {
-        return false;
-      }
-    }
+		/// <summary>
+		/// Determines whether this date is approximate.  This method always returns <c>false</c> for this instance.
+		/// </summary>
+		/// <value>
+		///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+		/// </value>
+		public override bool IsApproximate
+		{
+			get
+			{
+				return false;
+			}
+		}
 
-    /// <summary>
-    /// The formal representation of this duration.
-    /// </summary>
-    /// <value>
-    /// The formal representation of this duration.
-    /// </value>
-    public override String FormalString
-    {
-      get
-      {
-        StringBuilder duration = new StringBuilder("P");
+		/// <summary>
+		/// The formal representation of this duration.
+		/// </summary>
+		/// <value>
+		/// The formal representation of this duration.
+		/// </value>
+		public override String FormalString
+		{
+			get
+			{
+				StringBuilder duration = new StringBuilder("P");
 
-        if (years != null)
-        {
-          duration.Append(years).Append('Y');
-        }
+				if (years != null)
+				{
+					duration.Append(years).Append('Y');
+				}
 
-        if (months != null)
-        {
-          duration.Append(months).Append('M');
-        }
+				if (months != null)
+				{
+					duration.Append(months).Append('M');
+				}
 
-        if (days != null)
-        {
-          duration.Append(days).Append('D');
-        }
+				if (days != null)
+				{
+					duration.Append(days).Append('D');
+				}
 
-        if (hours != null || minutes != null || seconds != null)
-        {
-          duration.Append('T');
+				if (hours != null || minutes != null || seconds != null)
+				{
+					duration.Append('T');
 
-          if (hours != null)
-          {
-            duration.Append(hours).Append('H');
-          }
+					if (hours != null)
+					{
+						duration.Append(hours).Append('H');
+					}
 
-          if (minutes != null)
-          {
-            duration.Append(minutes).Append('M');
-          }
+					if (minutes != null)
+					{
+						duration.Append(minutes).Append('M');
+					}
 
-          if (seconds != null)
-          {
-            duration.Append(seconds).Append('S');
-          }
-        }
+					if (seconds != null)
+					{
+						duration.Append(seconds).Append('S');
+					}
+				}
 
-        return duration.ToString();
-      }
-    }
+				return duration.ToString();
+			}
+		}
 
-    /// <summary>
-    /// Gets the years of the current duration if applicable.
-    /// </summary>
-    /// <value>
-    /// The years of the current duration if applicable.
-    /// </value>
-    public Int32? Years
-    {
-      get
-      {
-        return years;
-      }
-    }
+		/// <summary>
+		/// Gets the years of the current duration if applicable.
+		/// </summary>
+		/// <value>
+		/// The years of the current duration if applicable.
+		/// </value>
+		public Int32? Years
+		{
+			get
+			{
+				return years;
+			}
+		}
 
-    /// <summary>
-    /// Gets the months of the current duration if applicable.
-    /// </summary>
-    /// <value>
-    /// The months of the current duration if applicable.
-    /// </value>
-    public Int32? Months
-    {
-      get
-      {
-        return months;
-      }
-    }
+		/// <summary>
+		/// Gets the months of the current duration if applicable.
+		/// </summary>
+		/// <value>
+		/// The months of the current duration if applicable.
+		/// </value>
+		public Int32? Months
+		{
+			get
+			{
+				return months;
+			}
+		}
 
-    /// <summary>
-    /// Gets the days of the current duration if applicable.
-    /// </summary>
-    /// <value>
-    /// The days of the current duration if applicable.
-    /// </value>
-    public Int32? Days
-    {
-      get
-      {
-        return days;
-      }
-    }
+		/// <summary>
+		/// Gets the days of the current duration if applicable.
+		/// </summary>
+		/// <value>
+		/// The days of the current duration if applicable.
+		/// </value>
+		public Int32? Days
+		{
+			get
+			{
+				return days;
+			}
+		}
 
-    /// <summary>
-    /// Gets the hours of the current duration if applicable.
-    /// </summary>
-    /// <value>
-    /// The hours of the current duration if applicable.
-    /// </value>
-    public Int32? Hours
-    {
-      get
-      {
-        return hours;
-      }
-    }
+		/// <summary>
+		/// Gets the hours of the current duration if applicable.
+		/// </summary>
+		/// <value>
+		/// The hours of the current duration if applicable.
+		/// </value>
+		public Int32? Hours
+		{
+			get
+			{
+				return hours;
+			}
+		}
 
-    /// <summary>
-    /// Gets the minutes of the current duration if applicable.
-    /// </summary>
-    /// <value>
-    /// The minutes of the current duration if applicable.
-    /// </value>
-    public Int32? Minutes
-    {
-      get
-      {
-        return minutes;
-      }
-    }
+		/// <summary>
+		/// Gets the minutes of the current duration if applicable.
+		/// </summary>
+		/// <value>
+		/// The minutes of the current duration if applicable.
+		/// </value>
+		public Int32? Minutes
+		{
+			get
+			{
+				return minutes;
+			}
+		}
 
-    /// <summary>
-    /// Gets the seconds of the current duration if applicable.
-    /// </summary>
-    /// <value>
-    /// The seconds of the current duration if applicable.
-    /// </value>
-    public Int32? Seconds
-    {
-      get
-      {
-        return seconds;
-      }
-    }
-  }
+		/// <summary>
+		/// Gets the seconds of the current duration if applicable.
+		/// </summary>
+		/// <value>
+		/// The seconds of the current duration if applicable.
+		/// </value>
+		public Int32? Seconds
+		{
+			get
+			{
+				return seconds;
+			}
+		}
+	}
 }

--- a/GEDCOM X Date/GedcomxDateRange.cs
+++ b/GEDCOM X Date/GedcomxDateRange.cs
@@ -5,214 +5,214 @@ using System.Text;
 
 namespace Gedcomx.Date
 {
-	/// <summary>
-	/// Represents a GEDCOM X date range.
-	/// </summary>
-	public class GedcomxDateRange : GedcomxDate
-	{
-		private bool approximate = false;
-		private GedcomxDateSimple start = null;
-		private GedcomxDateDuration duration = null;
-		private GedcomxDateSimple end = null;
+  /// <summary>
+  /// Represents a GEDCOM X date range.
+  /// </summary>
+  public class GedcomxDateRange : GedcomxDate
+  {
+    private bool approximate = false;
+    private GedcomxDateSimple start = null;
+    private GedcomxDateDuration duration = null;
+    private GedcomxDateSimple end = null;
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="GedcomxDateRange"/> class.
-		/// </summary>
-		/// <param name="date">The formal date string that describes a GEDCOM X date range.</param>
-		/// <exception cref="Gedcomx.Date.GedcomxDateException">
-		/// Thrown if the formal date is null, empty, or does not meet the expected format.
-		/// </exception>
-		public GedcomxDateRange(String date)
-		{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GedcomxDateRange"/> class.
+    /// </summary>
+    /// <param name="date">The formal date string that describes a GEDCOM X date range.</param>
+    /// <exception cref="Gedcomx.Date.GedcomxDateException">
+    /// Thrown if the formal date is null, empty, or does not meet the expected format.
+    /// </exception>
+    public GedcomxDateRange(String date)
+    {
 
-			if (date == null || date.Length < 1)
-			{
-				throw new GedcomxDateException("Invalid Range");
-			}
+      if (date == null || date.Length < 1)
+      {
+        throw new GedcomxDateException("Invalid Range");
+      }
 
-			String range = date;
+      String range = date;
 
-			// If range starts with A it is recurring
-			if (date[0] == 'A')
-			{
-				approximate = true;
-				range = date.Substring(1);
-			}
+      // If range starts with A it is recurring
+      if (date[0] == 'A')
+      {
+        approximate = true;
+        range = date.Substring(1);
+      }
 
-			// / is required
-			if (!date.Contains("/"))
-			{
-				throw new GedcomxDateException("Invalid Range: / is required");
-			}
+      // / is required
+      if (!date.Contains("/"))
+      {
+        throw new GedcomxDateException("Invalid Range: / is required");
+      }
 
-			/*
-			 * range -> parts
-			 * / -> []
-			 * +1000/ -> ["+1000"]
-			 * /+1000 -> ["","+1000"]
-			 * +1000/+2000 -> ["+1000","+2000"]
-			 */
-			String[] parts = range.Split('/');
+      /*
+       * range -> parts
+       * / -> []
+       * +1000/ -> ["+1000"]
+       * /+1000 -> ["","+1000"]
+       * +1000/+2000 -> ["+1000","+2000"]
+       */
+      String[] parts = range.Split('/');
 
-			if (parts.Length < 1 || parts.Length > 2)
-			{
-				throw new GedcomxDateException("Invalid Range: One or two parts are required");
-			}
+      if (parts.Length < 1 || parts.Length > 2)
+      {
+        throw new GedcomxDateException("Invalid Range: One or two parts are required");
+      }
 
-			if (!parts[0].Equals(""))
-			{
-				try
-				{
-					start = new GedcomxDateSimple(parts[0]);
-				}
-				catch (GedcomxDateException e)
-				{
-					throw new GedcomxDateException(e.Message + " in Range Start Date");
-				}
-			}
+      if (!parts[0].Equals(""))
+      {
+        try
+        {
+          start = new GedcomxDateSimple(parts[0]);
+        }
+        catch (GedcomxDateException e)
+        {
+          throw new GedcomxDateException(e.Message + " in Range Start Date");
+        }
+      }
 
-			if (parts.Length == 2)
-			{
-				if (parts[1][0] == 'P')
-				{
-					if (start == null)
-					{
-						throw new GedcomxDateException("Invalid Range: A range may not end with a duration if missing a start date");
-					}
-					try
-					{
-						duration = new GedcomxDateDuration(parts[1]);
-					}
-					catch (GedcomxDateException e)
-					{
-						throw new GedcomxDateException(e.Message + " in Range End Duration");
-					}
-					// Use the duration to calculate the end date
-					end = GedcomxDateUtil.AddDuration(start, duration);
-				}
-				else
-				{
-					try
-					{
-						end = new GedcomxDateSimple(parts[1]);
-					}
-					catch (GedcomxDateException e)
-					{
-						throw new GedcomxDateException(e.Message + " in Range End Date");
-					}
-					if (start != null)
-					{
-						duration = GedcomxDateUtil.GetDuration(start, end);
-					}
-				}
-			}
-		}
+      if (parts.Length == 2)
+      {
+        if (parts[1][0] == 'P')
+        {
+          if (start == null)
+          {
+            throw new GedcomxDateException("Invalid Range: A range may not end with a duration if missing a start date");
+          }
+          try
+          {
+            duration = new GedcomxDateDuration(parts[1]);
+          }
+          catch (GedcomxDateException e)
+          {
+            throw new GedcomxDateException(e.Message + " in Range End Duration");
+          }
+          // Use the duration to calculate the end date
+          end = GedcomxDateUtil.AddDuration(start, duration);
+        }
+        else
+        {
+          try
+          {
+            end = new GedcomxDateSimple(parts[1]);
+          }
+          catch (GedcomxDateException e)
+          {
+            throw new GedcomxDateException(e.Message + " in Range End Date");
+          }
+          if (start != null)
+          {
+            duration = GedcomxDateUtil.GetDuration(start, end);
+          }
+        }
+      }
+    }
 
-		/// <summary>
-		/// Gets the simple start date of the current date range.
-		/// </summary>
-		/// <value>
-		/// The simple start date of the current date range.
-		/// </value>
-		public GedcomxDateSimple Start
-		{
-			get
-			{
-				return start;
-			}
-		}
+    /// <summary>
+    /// Gets the simple start date of the current date range.
+    /// </summary>
+    /// <value>
+    /// The simple start date of the current date range.
+    /// </value>
+    public GedcomxDateSimple Start
+    {
+      get
+      {
+        return start;
+      }
+    }
 
-		/// <summary>
-		/// Gets the duration between the start and end dates.
-		/// </summary>
-		/// <value>
-		/// The duration between the start and end dates.
-		/// </value>
-		public GedcomxDateDuration Duration
-		{
-			get
-			{
-				return duration;
-			}
-		}
+    /// <summary>
+    /// Gets the duration between the start and end dates.
+    /// </summary>
+    /// <value>
+    /// The duration between the start and end dates.
+    /// </value>
+    public GedcomxDateDuration Duration
+    {
+      get
+      {
+        return duration;
+      }
+    }
 
-		/// <summary>
-		/// Gets the simple end date of the current date range.
-		/// </summary>
-		/// <value>
-		/// The simple end date of the current date range.
-		/// </value>
-		public GedcomxDateSimple End
-		{
-			get
-			{
-				return end;
-			}
-		}
+    /// <summary>
+    /// Gets the simple end date of the current date range.
+    /// </summary>
+    /// <value>
+    /// The simple end date of the current date range.
+    /// </value>
+    public GedcomxDateSimple End
+    {
+      get
+      {
+        return end;
+      }
+    }
 
-		/// <summary>
-		/// Gets the type of GEDCOM X date. This property always returns RANGE for this instance.
-		/// </summary>
-		/// <value>
-		/// The type of GEDCOM X date.
-		/// </value>
-		public override GedcomxDateType Type
-		{
-			get
-			{
-				return GedcomxDateType.RANGE;
-			}
-		}
+    /// <summary>
+    /// Gets the type of GEDCOM X date. This property always returns RANGE for this instance.
+    /// </summary>
+    /// <value>
+    /// The type of GEDCOM X date.
+    /// </value>
+    public override GedcomxDateType Type
+    {
+      get
+      {
+        return GedcomxDateType.RANGE;
+      }
+    }
 
-		/// <summary>
-		/// Determines whether this date is approximate.
-		/// </summary>
-		/// <value>
-		///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-		/// </value>
-		public override bool IsApproximate
-		{
-			get
-			{
-				return approximate;
-			}
-		}
+    /// <summary>
+    /// Determines whether this date is approximate.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+    /// </value>
+    public override bool IsApproximate
+    {
+      get
+      {
+        return approximate;
+      }
+    }
 
-		/// <summary>
-		/// The formal representation of this date.
-		/// </summary>
-		/// <value>
-		/// The formal representation of this date.
-		/// </value>
-		public override String FormalString
-		{
-			get
-			{
-				StringBuilder range = new StringBuilder();
+    /// <summary>
+    /// The formal representation of this date.
+    /// </summary>
+    /// <value>
+    /// The formal representation of this date.
+    /// </value>
+    public override String FormalString
+    {
+      get
+      {
+        StringBuilder range = new StringBuilder();
 
-				if (approximate)
-				{
-					range.Append('A');
-				}
+        if (approximate)
+        {
+          range.Append('A');
+        }
 
-				if (start != null)
-				{
-					range.Append(start.FormalString);
-				}
+        if (start != null)
+        {
+          range.Append(start.FormalString);
+        }
 
-				range.Append('/');
+        range.Append('/');
 
-				if (duration != null)
-				{
-					range.Append(duration.FormalString);
-				}
-				else if (end != null)
-				{
-					range.Append(end.FormalString);
-				}
+        if (duration != null)
+        {
+          range.Append(duration.FormalString);
+        }
+        else if (end != null)
+        {
+          range.Append(end.FormalString);
+        }
 
-				return range.ToString();
-			}
-		}
-	}
+        return range.ToString();
+      }
+    }
+  }
 }

--- a/GEDCOM X Date/GedcomxDateRange.cs
+++ b/GEDCOM X Date/GedcomxDateRange.cs
@@ -5,214 +5,214 @@ using System.Text;
 
 namespace Gedcomx.Date
 {
-  /// <summary>
-  /// Represents a GEDCOM X date range.
-  /// </summary>
-  public class GedcomxDateRange : GedcomxDate
-  {
-    private bool approximate = false;
-    private GedcomxDateSimple start = null;
-    private GedcomxDateDuration duration = null;
-    private GedcomxDateSimple end = null;
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="GedcomxDateRange"/> class.
+    /// Represents a GEDCOM X date range.
     /// </summary>
-    /// <param name="date">The formal date string that describes a GEDCOM X date range.</param>
-    /// <exception cref="Gedcomx.Date.GedcomxDateException">
-    /// Thrown if the formal date is null, empty, or does not meet the expected format.
-    /// </exception>
-    public GedcomxDateRange(String date)
+    public class GedcomxDateRange : GedcomxDate
     {
+        private bool approximate = false;
+        private GedcomxDateSimple start = null;
+        private GedcomxDateDuration duration = null;
+        private GedcomxDateSimple end = null;
 
-      if (date == null || date.Length < 1)
-      {
-        throw new GedcomxDateException("Invalid Range");
-      }
-
-      String range = date;
-
-      // If range starts with A it is recurring
-      if (date[0] == 'A')
-      {
-        approximate = true;
-        range = date.Substring(1);
-      }
-
-      // / is required
-      if (!date.Contains("/"))
-      {
-        throw new GedcomxDateException("Invalid Range: / is required");
-      }
-
-      /*
-       * range -> parts
-       * / -> []
-       * +1000/ -> ["+1000"]
-       * /+1000 -> ["","+1000"]
-       * +1000/+2000 -> ["+1000","+2000"]
-       */
-      String[] parts = range.Split('/');
-
-      if (parts.Length < 1 || parts.Length > 2)
-      {
-        throw new GedcomxDateException("Invalid Range: One or two parts are required");
-      }
-
-      if (!parts[0].Equals(""))
-      {
-        try
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GedcomxDateRange"/> class.
+        /// </summary>
+        /// <param name="date">The formal date string that describes a GEDCOM X date range.</param>
+        /// <exception cref="Gedcomx.Date.GedcomxDateException">
+        /// Thrown if the formal date is null, empty, or does not meet the expected format.
+        /// </exception>
+        public GedcomxDateRange(String date)
         {
-          start = new GedcomxDateSimple(parts[0]);
-        }
-        catch (GedcomxDateException e)
-        {
-          throw new GedcomxDateException(e.Message + " in Range Start Date");
-        }
-      }
 
-      if (parts.Length == 2)
-      {
-        if (parts[1][0] == 'P')
-        {
-          if (start == null)
-          {
-            throw new GedcomxDateException("Invalid Range: A range may not end with a duration if missing a start date");
-          }
-          try
-          {
-            duration = new GedcomxDateDuration(parts[1]);
-          }
-          catch (GedcomxDateException e)
-          {
-            throw new GedcomxDateException(e.Message + " in Range End Duration");
-          }
-          // Use the duration to calculate the end date
-          end = GedcomxDateUtil.AddDuration(start, duration);
+            if (date == null || date.Length < 1)
+            {
+                throw new GedcomxDateException("Invalid Range");
+            }
+
+            String range = date;
+
+            // If range starts with A it is recurring
+            if (date[0] == 'A')
+            {
+                approximate = true;
+                range = date.Substring(1);
+            }
+
+            // / is required
+            if (!date.Contains("/"))
+            {
+                throw new GedcomxDateException("Invalid Range: / is required");
+            }
+
+            /*
+             * range -> parts
+             * / -> []
+             * +1000/ -> ["+1000"]
+             * /+1000 -> ["","+1000"]
+             * +1000/+2000 -> ["+1000","+2000"]
+             */
+            String[] parts = range.Split('/');
+
+            if (parts.Length < 1 || parts.Length > 2)
+            {
+                throw new GedcomxDateException("Invalid Range: One or two parts are required");
+            }
+
+            if (!parts[0].Equals(""))
+            {
+                try
+                {
+                    start = new GedcomxDateSimple(parts[0]);
+                }
+                catch (GedcomxDateException e)
+                {
+                    throw new GedcomxDateException(e.Message + " in Range Start Date");
+                }
+            }
+
+            if (parts.Length == 2)
+            {
+                if (parts[1][0] == 'P')
+                {
+                    if (start == null)
+                    {
+                        throw new GedcomxDateException("Invalid Range: A range may not end with a duration if missing a start date");
+                    }
+                    try
+                    {
+                        duration = new GedcomxDateDuration(parts[1]);
+                    }
+                    catch (GedcomxDateException e)
+                    {
+                        throw new GedcomxDateException(e.Message + " in Range End Duration");
+                    }
+                    // Use the duration to calculate the end date
+                    end = GedcomxDateUtil.AddDuration(start, duration);
+                }
+                else
+                {
+                    try
+                    {
+                        end = new GedcomxDateSimple(parts[1]);
+                    }
+                    catch (GedcomxDateException e)
+                    {
+                        throw new GedcomxDateException(e.Message + " in Range End Date");
+                    }
+                    if (start != null)
+                    {
+                        duration = GedcomxDateUtil.GetDuration(start, end);
+                    }
+                }
+            }
         }
-        else
+
+        /// <summary>
+        /// Gets the simple start date of the current date range.
+        /// </summary>
+        /// <value>
+        /// The simple start date of the current date range.
+        /// </value>
+        public GedcomxDateSimple Start
         {
-          try
-          {
-            end = new GedcomxDateSimple(parts[1]);
-          }
-          catch (GedcomxDateException e)
-          {
-            throw new GedcomxDateException(e.Message + " in Range End Date");
-          }
-          if (start != null)
-          {
-            duration = GedcomxDateUtil.GetDuration(start, end);
-          }
+            get
+            {
+                return start;
+            }
         }
-      }
+
+        /// <summary>
+        /// Gets the duration between the start and end dates.
+        /// </summary>
+        /// <value>
+        /// The duration between the start and end dates.
+        /// </value>
+        public GedcomxDateDuration Duration
+        {
+            get
+            {
+                return duration;
+            }
+        }
+
+        /// <summary>
+        /// Gets the simple end date of the current date range.
+        /// </summary>
+        /// <value>
+        /// The simple end date of the current date range.
+        /// </value>
+        public GedcomxDateSimple End
+        {
+            get
+            {
+                return end;
+            }
+        }
+
+        /// <summary>
+        /// Gets the type of GEDCOM X date. This property always returns RANGE for this instance.
+        /// </summary>
+        /// <value>
+        /// The type of GEDCOM X date.
+        /// </value>
+        public override GedcomxDateType Type
+        {
+            get
+            {
+                return GedcomxDateType.RANGE;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether this date is approximate.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+        /// </value>
+        public override bool IsApproximate
+        {
+            get
+            {
+                return approximate;
+            }
+        }
+
+        /// <summary>
+        /// The formal representation of this date.
+        /// </summary>
+        /// <value>
+        /// The formal representation of this date.
+        /// </value>
+        public override String FormalString
+        {
+            get
+            {
+                StringBuilder range = new StringBuilder();
+
+                if (approximate)
+                {
+                    range.Append('A');
+                }
+
+                if (start != null)
+                {
+                    range.Append(start.FormalString);
+                }
+
+                range.Append('/');
+
+                if (duration != null)
+                {
+                    range.Append(duration.FormalString);
+                }
+                else if (end != null)
+                {
+                    range.Append(end.FormalString);
+                }
+
+                return range.ToString();
+            }
+        }
     }
-
-    /// <summary>
-    /// Gets the simple start date of the current date range.
-    /// </summary>
-    /// <value>
-    /// The simple start date of the current date range.
-    /// </value>
-    public GedcomxDateSimple Start
-    {
-      get
-      {
-        return start;
-      }
-    }
-
-    /// <summary>
-    /// Gets the duration between the start and end dates.
-    /// </summary>
-    /// <value>
-    /// The duration between the start and end dates.
-    /// </value>
-    public GedcomxDateDuration Duration
-    {
-      get
-      {
-        return duration;
-      }
-    }
-
-    /// <summary>
-    /// Gets the simple end date of the current date range.
-    /// </summary>
-    /// <value>
-    /// The simple end date of the current date range.
-    /// </value>
-    public GedcomxDateSimple End
-    {
-      get
-      {
-        return end;
-      }
-    }
-
-    /// <summary>
-    /// Gets the type of GEDCOM X date. This property always returns RANGE for this instance.
-    /// </summary>
-    /// <value>
-    /// The type of GEDCOM X date.
-    /// </value>
-    public override GedcomxDateType Type
-    {
-      get
-      {
-        return GedcomxDateType.RANGE;
-      }
-    }
-
-    /// <summary>
-    /// Determines whether this date is approximate.
-    /// </summary>
-    /// <value>
-    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-    /// </value>
-    public override bool IsApproximate
-    {
-      get
-      {
-        return approximate;
-      }
-    }
-
-    /// <summary>
-    /// The formal representation of this date.
-    /// </summary>
-    /// <value>
-    /// The formal representation of this date.
-    /// </value>
-    public override String FormalString
-    {
-      get
-      {
-        StringBuilder range = new StringBuilder();
-
-        if (approximate)
-        {
-          range.Append('A');
-        }
-
-        if (start != null)
-        {
-          range.Append(start.FormalString);
-        }
-
-        range.Append('/');
-
-        if (duration != null)
-        {
-          range.Append(duration.FormalString);
-        }
-        else if (end != null)
-        {
-          range.Append(end.FormalString);
-        }
-
-        return range.ToString();
-      }
-    }
-  }
 }

--- a/GEDCOM X Date/GedcomxDateRange.cs
+++ b/GEDCOM X Date/GedcomxDateRange.cs
@@ -5,214 +5,214 @@ using System.Text;
 
 namespace Gedcomx.Date
 {
-  /// <summary>
-  /// Represents a GEDCOM X date range.
-  /// </summary>
-  public class GedcomxDateRange : GedcomxDate
-  {
-    private bool approximate = false;
-    private GedcomxDateSimple start = null;
-    private GedcomxDateDuration duration = null;
-    private GedcomxDateSimple end = null;
+	/// <summary>
+	/// Represents a GEDCOM X date range.
+	/// </summary>
+	public class GedcomxDateRange : GedcomxDate
+	{
+		private bool approximate = false;
+		private GedcomxDateSimple start = null;
+		private GedcomxDateDuration duration = null;
+		private GedcomxDateSimple end = null;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="GedcomxDateRange"/> class.
-    /// </summary>
-    /// <param name="date">The formal date string that describes a GEDCOM X date range.</param>
-    /// <exception cref="Gedcomx.Date.GedcomxDateException">
-    /// Thrown if the formal date is null, empty, or does not meet the expected format.
-    /// </exception>
-    public GedcomxDateRange(String date)
-    {
+		/// <summary>
+		/// Initializes a new instance of the <see cref="GedcomxDateRange"/> class.
+		/// </summary>
+		/// <param name="date">The formal date string that describes a GEDCOM X date range.</param>
+		/// <exception cref="Gedcomx.Date.GedcomxDateException">
+		/// Thrown if the formal date is null, empty, or does not meet the expected format.
+		/// </exception>
+		public GedcomxDateRange(String date)
+		{
 
-      if (date == null || date.Length < 1)
-      {
-        throw new GedcomxDateException("Invalid Range");
-      }
+			if (date == null || date.Length < 1)
+			{
+				throw new GedcomxDateException("Invalid Range");
+			}
 
-      String range = date;
+			String range = date;
 
-      // If range starts with A it is recurring
-      if (date[0] == 'A')
-      {
-        approximate = true;
-        range = date.Substring(1);
-      }
+			// If range starts with A it is recurring
+			if (date[0] == 'A')
+			{
+				approximate = true;
+				range = date.Substring(1);
+			}
 
-      // / is required
-      if (!date.Contains("/"))
-      {
-        throw new GedcomxDateException("Invalid Range: / is required");
-      }
+			// / is required
+			if (!date.Contains("/"))
+			{
+				throw new GedcomxDateException("Invalid Range: / is required");
+			}
 
-      /*
-       * range -> parts
-       * / -> []
-       * +1000/ -> ["+1000"]
-       * /+1000 -> ["","+1000"]
-       * +1000/+2000 -> ["+1000","+2000"]
-       */
-      String[] parts = range.Split('/');
+			/*
+			 * range -> parts
+			 * / -> []
+			 * +1000/ -> ["+1000"]
+			 * /+1000 -> ["","+1000"]
+			 * +1000/+2000 -> ["+1000","+2000"]
+			 */
+			String[] parts = range.Split('/');
 
-      if (parts.Length < 1 || parts.Length > 2)
-      {
-        throw new GedcomxDateException("Invalid Range: One or two parts are required");
-      }
+			if (parts.Length < 1 || parts.Length > 2)
+			{
+				throw new GedcomxDateException("Invalid Range: One or two parts are required");
+			}
 
-      if (!parts[0].Equals(""))
-      {
-        try
-        {
-          start = new GedcomxDateSimple(parts[0]);
-        }
-        catch (GedcomxDateException e)
-        {
-          throw new GedcomxDateException(e.Message + " in Range Start Date");
-        }
-      }
+			if (!parts[0].Equals(""))
+			{
+				try
+				{
+					start = new GedcomxDateSimple(parts[0]);
+				}
+				catch (GedcomxDateException e)
+				{
+					throw new GedcomxDateException(e.Message + " in Range Start Date");
+				}
+			}
 
-      if (parts.Length == 2)
-      {
-        if (parts[1][0] == 'P')
-        {
-          if (start == null)
-          {
-            throw new GedcomxDateException("Invalid Range: A range may not end with a duration if missing a start date");
-          }
-          try
-          {
-            duration = new GedcomxDateDuration(parts[1]);
-          }
-          catch (GedcomxDateException e)
-          {
-            throw new GedcomxDateException(e.Message + " in Range End Duration");
-          }
-          // Use the duration to calculate the end date
-          end = GedcomxDateUtil.AddDuration(start, duration);
-        }
-        else
-        {
-          try
-          {
-            end = new GedcomxDateSimple(parts[1]);
-          }
-          catch (GedcomxDateException e)
-          {
-            throw new GedcomxDateException(e.Message + " in Range End Date");
-          }
-          if (start != null)
-          {
-            duration = GedcomxDateUtil.GetDuration(start, end);
-          }
-        }
-      }
-    }
+			if (parts.Length == 2)
+			{
+				if (parts[1][0] == 'P')
+				{
+					if (start == null)
+					{
+						throw new GedcomxDateException("Invalid Range: A range may not end with a duration if missing a start date");
+					}
+					try
+					{
+						duration = new GedcomxDateDuration(parts[1]);
+					}
+					catch (GedcomxDateException e)
+					{
+						throw new GedcomxDateException(e.Message + " in Range End Duration");
+					}
+					// Use the duration to calculate the end date
+					end = GedcomxDateUtil.AddDuration(start, duration);
+				}
+				else
+				{
+					try
+					{
+						end = new GedcomxDateSimple(parts[1]);
+					}
+					catch (GedcomxDateException e)
+					{
+						throw new GedcomxDateException(e.Message + " in Range End Date");
+					}
+					if (start != null)
+					{
+						duration = GedcomxDateUtil.GetDuration(start, end);
+					}
+				}
+			}
+		}
 
-    /// <summary>
-    /// Gets the simple start date of the current date range.
-    /// </summary>
-    /// <value>
-    /// The simple start date of the current date range.
-    /// </value>
-    public GedcomxDateSimple Start
-    {
-      get
-      {
-        return start;
-      }
-    }
+		/// <summary>
+		/// Gets the simple start date of the current date range.
+		/// </summary>
+		/// <value>
+		/// The simple start date of the current date range.
+		/// </value>
+		public GedcomxDateSimple Start
+		{
+			get
+			{
+				return start;
+			}
+		}
 
-    /// <summary>
-    /// Gets the duration between the start and end dates.
-    /// </summary>
-    /// <value>
-    /// The duration between the start and end dates.
-    /// </value>
-    public GedcomxDateDuration Duration
-    {
-      get
-      {
-        return duration;
-      }
-    }
+		/// <summary>
+		/// Gets the duration between the start and end dates.
+		/// </summary>
+		/// <value>
+		/// The duration between the start and end dates.
+		/// </value>
+		public GedcomxDateDuration Duration
+		{
+			get
+			{
+				return duration;
+			}
+		}
 
-    /// <summary>
-    /// Gets the simple end date of the current date range.
-    /// </summary>
-    /// <value>
-    /// The simple end date of the current date range.
-    /// </value>
-    public GedcomxDateSimple End
-    {
-      get
-      {
-        return end;
-      }
-    }
+		/// <summary>
+		/// Gets the simple end date of the current date range.
+		/// </summary>
+		/// <value>
+		/// The simple end date of the current date range.
+		/// </value>
+		public GedcomxDateSimple End
+		{
+			get
+			{
+				return end;
+			}
+		}
 
-    /// <summary>
-    /// Gets the type of GEDCOM X date. This property always returns RANGE for this instance.
-    /// </summary>
-    /// <value>
-    /// The type of GEDCOM X date.
-    /// </value>
-    public override GedcomxDateType Type
-    {
-      get
-      {
-        return GedcomxDateType.RANGE;
-      }
-    }
+		/// <summary>
+		/// Gets the type of GEDCOM X date. This property always returns RANGE for this instance.
+		/// </summary>
+		/// <value>
+		/// The type of GEDCOM X date.
+		/// </value>
+		public override GedcomxDateType Type
+		{
+			get
+			{
+				return GedcomxDateType.RANGE;
+			}
+		}
 
-    /// <summary>
-    /// Determines whether this date is approximate.
-    /// </summary>
-    /// <value>
-    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-    /// </value>
-    public override bool IsApproximate
-    {
-      get
-      {
-        return approximate;
-      }
-    }
+		/// <summary>
+		/// Determines whether this date is approximate.
+		/// </summary>
+		/// <value>
+		///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+		/// </value>
+		public override bool IsApproximate
+		{
+			get
+			{
+				return approximate;
+			}
+		}
 
-    /// <summary>
-    /// The formal representation of this date.
-    /// </summary>
-    /// <value>
-    /// The formal representation of this date.
-    /// </value>
-    public override String FormalString
-    {
-      get
-      {
-        StringBuilder range = new StringBuilder();
+		/// <summary>
+		/// The formal representation of this date.
+		/// </summary>
+		/// <value>
+		/// The formal representation of this date.
+		/// </value>
+		public override String FormalString
+		{
+			get
+			{
+				StringBuilder range = new StringBuilder();
 
-        if (approximate)
-        {
-          range.Append('A');
-        }
+				if (approximate)
+				{
+					range.Append('A');
+				}
 
-        if (start != null)
-        {
-          range.Append(start.FormalString);
-        }
+				if (start != null)
+				{
+					range.Append(start.FormalString);
+				}
 
-        range.Append('/');
+				range.Append('/');
 
-        if (duration != null)
-        {
-          range.Append(duration.FormalString);
-        }
-        else if (end != null)
-        {
-          range.Append(end.FormalString);
-        }
+				if (duration != null)
+				{
+					range.Append(duration.FormalString);
+				}
+				else if (end != null)
+				{
+					range.Append(end.FormalString);
+				}
 
-        return range.ToString();
-      }
-    }
-  }
+				return range.ToString();
+			}
+		}
+	}
 }

--- a/GEDCOM X Date/GedcomxDateRange.cs
+++ b/GEDCOM X Date/GedcomxDateRange.cs
@@ -5,208 +5,214 @@ using System.Text;
 
 namespace Gedcomx.Date
 {
+  /// <summary>
+  /// Represents a GEDCOM X date range.
+  /// </summary>
+  public class GedcomxDateRange : GedcomxDate
+  {
+    private bool approximate = false;
+    private GedcomxDateSimple start = null;
+    private GedcomxDateDuration duration = null;
+    private GedcomxDateSimple end = null;
+
     /// <summary>
-    /// Represents a GEDCOM X date range.
+    /// Initializes a new instance of the <see cref="GedcomxDateRange"/> class.
     /// </summary>
-    public class GedcomxDateRange : GedcomxDate
+    /// <param name="date">The formal date string that describes a GEDCOM X date range.</param>
+    /// <exception cref="Gedcomx.Date.GedcomxDateException">
+    /// Thrown if the formal date is null, empty, or does not meet the expected format.
+    /// </exception>
+    public GedcomxDateRange(String date)
     {
-        private bool approximate = false;
-        private GedcomxDateSimple start = null;
-        private GedcomxDateDuration duration = null;
-        private GedcomxDateSimple end = null;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GedcomxDateRange"/> class.
-        /// </summary>
-        /// <param name="date">The formal date string that describes a GEDCOM X date range.</param>
-        /// <exception cref="Gedcomx.Date.GedcomxDateException">
-        /// Thrown if the formal date is null, empty, or does not meet the expected format.
-        /// </exception>
-        public GedcomxDateRange(String date)
+      if (date == null || date.Length < 1)
+      {
+        throw new GedcomxDateException("Invalid Range");
+      }
+
+      String range = date;
+
+      // If range starts with A it is recurring
+      if (date[0] == 'A')
+      {
+        approximate = true;
+        range = date.Substring(1);
+      }
+
+      // / is required
+      if (!date.Contains("/"))
+      {
+        throw new GedcomxDateException("Invalid Range: / is required");
+      }
+
+      /*
+       * range -> parts
+       * / -> []
+       * +1000/ -> ["+1000"]
+       * /+1000 -> ["","+1000"]
+       * +1000/+2000 -> ["+1000","+2000"]
+       */
+      String[] parts = range.Split('/');
+
+      if (parts.Length < 1 || parts.Length > 2)
+      {
+        throw new GedcomxDateException("Invalid Range: One or two parts are required");
+      }
+
+      if (!parts[0].Equals(""))
+      {
+        try
         {
-
-            if (date == null || date.Length < 1)
-            {
-                throw new GedcomxDateException("Invalid Range");
-            }
-
-            String range = date;
-
-            // If range starts with A it is recurring
-            if (date[0] == 'A')
-            {
-                approximate = true;
-                range = date.Substring(1);
-            }
-
-            // / is required
-            if (!date.Contains("/"))
-            {
-                throw new GedcomxDateException("Invalid Range: / is required");
-            }
-
-            /*
-             * range -> parts
-             * / -> []
-             * +1000/ -> ["+1000"]
-             * /+1000 -> ["","+1000"]
-             * +1000/+2000 -> ["+1000","+2000"]
-             */
-            String[] parts = range.Split('/');
-
-            if (parts.Length < 1 || parts.Length > 2)
-            {
-                throw new GedcomxDateException("Invalid Range: One or two parts are required");
-            }
-
-            if (!parts[0].Equals(""))
-            {
-                try
-                {
-                    start = new GedcomxDateSimple(parts[0]);
-                }
-                catch (GedcomxDateException e)
-                {
-                    throw new GedcomxDateException(e.Message + " in Range Start Date");
-                }
-            }
-
-            if (parts.Length == 2)
-            {
-                if (parts[1][0] == 'P')
-                {
-                    if (start == null)
-                    {
-                        throw new GedcomxDateException("Invalid Range: A range may not end with a duration if missing a start date");
-                    }
-                    try
-                    {
-                        duration = new GedcomxDateDuration(parts[1]);
-                    }
-                    catch (GedcomxDateException e)
-                    {
-                        throw new GedcomxDateException(e.Message + " in Range End Duration");
-                    }
-                    // Use the duration to calculate the end date
-                    end = GedcomxDateUtil.AddDuration(start, duration);
-                }
-                else
-                {
-                    try
-                    {
-                        end = new GedcomxDateSimple(parts[1]);
-                    }
-                    catch (GedcomxDateException e)
-                    {
-                        throw new GedcomxDateException(e.Message + " in Range End Date");
-                    }
-                    if (start != null)
-                    {
-                        duration = GedcomxDateUtil.GetDuration(start, end);
-                    }
-                }
-            }
+          start = new GedcomxDateSimple(parts[0]);
         }
-
-        /// <summary>
-        /// Gets the simple start date of the current date range.
-        /// </summary>
-        /// <value>
-        /// The simple start date of the current date range.
-        /// </value>
-        public GedcomxDateSimple Start
+        catch (GedcomxDateException e)
         {
-            get
-            {
-                return start;
-            }
+          throw new GedcomxDateException(e.Message + " in Range Start Date");
         }
+      }
 
-        /// <summary>
-        /// Gets the duration between the start and end dates.
-        /// </summary>
-        /// <value>
-        /// The duration between the start and end dates.
-        /// </value>
-        public GedcomxDateDuration Duration
+      if (parts.Length == 2)
+      {
+        if (parts[1][0] == 'P')
         {
-            get
-            {
-                return duration;
-            }
+          if (start == null)
+          {
+            throw new GedcomxDateException("Invalid Range: A range may not end with a duration if missing a start date");
+          }
+          try
+          {
+            duration = new GedcomxDateDuration(parts[1]);
+          }
+          catch (GedcomxDateException e)
+          {
+            throw new GedcomxDateException(e.Message + " in Range End Duration");
+          }
+          // Use the duration to calculate the end date
+          end = GedcomxDateUtil.AddDuration(start, duration);
         }
-
-        /// <summary>
-        /// Gets the simple end date of the current date range.
-        /// </summary>
-        /// <value>
-        /// The simple end date of the current date range.
-        /// </value>
-        public GedcomxDateSimple End
+        else
         {
-            get
-            {
-                return end;
-            }
+          try
+          {
+            end = new GedcomxDateSimple(parts[1]);
+          }
+          catch (GedcomxDateException e)
+          {
+            throw new GedcomxDateException(e.Message + " in Range End Date");
+          }
+          if (start != null)
+          {
+            duration = GedcomxDateUtil.GetDuration(start, end);
+          }
         }
-
-        /// <summary>
-        /// Gets the type of GEDCOM X date. This property always returns RANGE for this instance.
-        /// </summary>
-        /// <value>
-        /// The type of GEDCOM X date.
-        /// </value>
-        public override GedcomxDateType Type
-        {
-            get
-            {
-                return GedcomxDateType.RANGE;
-            }
-        }
-
-        /// <summary>
-        /// Determines whether this date is approximate.
-        /// </summary>
-        /// <returns>
-        ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-        /// </returns>
-        public override bool IsApproximate()
-        {
-            return approximate;
-        }
-
-        /// <summary>
-        /// The formal representation of this date.
-        /// </summary>
-        /// <returns>
-        /// The formal representation of this date.
-        /// </returns>
-        public override String ToFormalString()
-        {
-            StringBuilder range = new StringBuilder();
-
-            if (approximate)
-            {
-                range.Append('A');
-            }
-
-            if (start != null)
-            {
-                range.Append(start.ToFormalString());
-            }
-
-            range.Append('/');
-
-            if (duration != null)
-            {
-                range.Append(duration.ToFormalString());
-            }
-            else if (end != null)
-            {
-                range.Append(end.ToFormalString());
-            }
-
-            return range.ToString();
-        }
+      }
     }
+
+    /// <summary>
+    /// Gets the simple start date of the current date range.
+    /// </summary>
+    /// <value>
+    /// The simple start date of the current date range.
+    /// </value>
+    public GedcomxDateSimple Start
+    {
+      get
+      {
+        return start;
+      }
+    }
+
+    /// <summary>
+    /// Gets the duration between the start and end dates.
+    /// </summary>
+    /// <value>
+    /// The duration between the start and end dates.
+    /// </value>
+    public GedcomxDateDuration Duration
+    {
+      get
+      {
+        return duration;
+      }
+    }
+
+    /// <summary>
+    /// Gets the simple end date of the current date range.
+    /// </summary>
+    /// <value>
+    /// The simple end date of the current date range.
+    /// </value>
+    public GedcomxDateSimple End
+    {
+      get
+      {
+        return end;
+      }
+    }
+
+    /// <summary>
+    /// Gets the type of GEDCOM X date. This property always returns RANGE for this instance.
+    /// </summary>
+    /// <value>
+    /// The type of GEDCOM X date.
+    /// </value>
+    public override GedcomxDateType Type
+    {
+      get
+      {
+        return GedcomxDateType.RANGE;
+      }
+    }
+
+    /// <summary>
+    /// Determines whether this date is approximate.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+    /// </value>
+    public override bool IsApproximate
+    {
+      get
+      {
+        return approximate;
+      }
+    }
+
+    /// <summary>
+    /// The formal representation of this date.
+    /// </summary>
+    /// <value>
+    /// The formal representation of this date.
+    /// </value>
+    public override String FormalString
+    {
+      get
+      {
+        StringBuilder range = new StringBuilder();
+
+        if (approximate)
+        {
+          range.Append('A');
+        }
+
+        if (start != null)
+        {
+          range.Append(start.FormalString);
+        }
+
+        range.Append('/');
+
+        if (duration != null)
+        {
+          range.Append(duration.FormalString);
+        }
+        else if (end != null)
+        {
+          range.Append(end.FormalString);
+        }
+
+        return range.ToString();
+      }
+    }
+  }
 }

--- a/GEDCOM X Date/GedcomxDateRecurring.cs
+++ b/GEDCOM X Date/GedcomxDateRecurring.cs
@@ -5,207 +5,207 @@ using System.Text;
 
 namespace Gedcomx.Date
 {
-  /// <summary>
-  /// Represents a recurring GEDCOM X date.
-  /// </summary>
-  public class GedcomxDateRecurring : GedcomxDate
-  {
+	/// <summary>
+	/// Represents a recurring GEDCOM X date.
+	/// </summary>
+	public class GedcomxDateRecurring : GedcomxDate
+	{
 
-    private Int32? count = null;
-    private GedcomxDateRange range;
-    private GedcomxDateSimple end = null;
+		private Int32? count = null;
+		private GedcomxDateRange range;
+		private GedcomxDateSimple end = null;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="GedcomxDateRecurring"/> class.
-    /// </summary>
-    /// <param name="date">The recurring date string that describes a recurring GEDCOM X date.</param>
-    /// <exception cref="Gedcomx.Date.GedcomxDateException">
-    /// Thrown if the formal date string is null, empty, or fails to meet the expected format. The specific reason will be given at runtime.
-    /// </exception>
-    public GedcomxDateRecurring(String date)
-    {
-      if (date == null || date.Length < 3)
-      {
-        throw new GedcomxDateException("Invalid Recurring Date");
-      }
+		/// <summary>
+		/// Initializes a new instance of the <see cref="GedcomxDateRecurring"/> class.
+		/// </summary>
+		/// <param name="date">The recurring date string that describes a recurring GEDCOM X date.</param>
+		/// <exception cref="Gedcomx.Date.GedcomxDateException">
+		/// Thrown if the formal date string is null, empty, or fails to meet the expected format. The specific reason will be given at runtime.
+		/// </exception>
+		public GedcomxDateRecurring(String date)
+		{
+			if (date == null || date.Length < 3)
+			{
+				throw new GedcomxDateException("Invalid Recurring Date");
+			}
 
-      if (date[0] != 'R')
-      {
-        throw new GedcomxDateException("Invalid Recurring Date: Must start with R");
-      }
+			if (date[0] != 'R')
+			{
+				throw new GedcomxDateException("Invalid Recurring Date: Must start with R");
+			}
 
-      String[] parts = date.Split('/');
+			String[] parts = date.Split('/');
 
-      if (parts.Length != 3)
-      {
-        throw new GedcomxDateException("Invalid Recurring Date: Must contain 3 parts");
-      }
+			if (parts.Length != 3)
+			{
+				throw new GedcomxDateException("Invalid Recurring Date: Must contain 3 parts");
+			}
 
-      // We must have a start and end
-      if (parts[1].Equals("") || parts[2].Equals(""))
-      {
-        throw new GedcomxDateException("Invalid Recurring Date: Range must have a start and an end");
-      }
+			// We must have a start and end
+			if (parts[1].Equals("") || parts[2].Equals(""))
+			{
+				throw new GedcomxDateException("Invalid Recurring Date: Range must have a start and an end");
+			}
 
-      String countNum = parts[0].Substring(1);
-      char[] countNumChars = parts[0].Substring(1).ToCharArray();
+			String countNum = parts[0].Substring(1);
+			char[] countNumChars = parts[0].Substring(1).ToCharArray();
 
-      if (countNumChars.Length > 0)
-      {
-        foreach (char c in countNumChars)
-        {
-          if (!Char.IsDigit(c))
-          {
-            throw new GedcomxDateException("Invalid Recurring Date: Malformed Count");
-          }
-        }
-        count = Int32.Parse(countNum);
-      }
-      try
-      {
-        range = new GedcomxDateRange(parts[1] + "/" + parts[2]);
-      }
-      catch (GedcomxDateException e)
-      {
-        throw new GedcomxDateException(e.Message + " in Recurring Range");
-      }
+			if (countNumChars.Length > 0)
+			{
+				foreach (char c in countNumChars)
+				{
+					if (!Char.IsDigit(c))
+					{
+						throw new GedcomxDateException("Invalid Recurring Date: Malformed Count");
+					}
+				}
+				count = Int32.Parse(countNum);
+			}
+			try
+			{
+				range = new GedcomxDateRange(parts[1] + "/" + parts[2]);
+			}
+			catch (GedcomxDateException e)
+			{
+				throw new GedcomxDateException(e.Message + " in Recurring Range");
+			}
 
-      // If we have a count set end
-      if (count != null)
-      {
-        end = GetNth(count.Value);
-      }
-    }
+			// If we have a count set end
+			if (count != null)
+			{
+				end = GetNth(count.Value);
+			}
+		}
 
-    /// <summary>
-    /// Gets the count of recurring instances if applicable.
-    /// </summary>
-    /// <value>
-    /// The count of recurring instances if applicable.
-    /// </value>
-    public Int32? Count
-    {
-      get
-      {
-        return count;
-      }
-    }
+		/// <summary>
+		/// Gets the count of recurring instances if applicable.
+		/// </summary>
+		/// <value>
+		/// The count of recurring instances if applicable.
+		/// </value>
+		public Int32? Count
+		{
+			get
+			{
+				return count;
+			}
+		}
 
-    /// <summary>
-    /// Gets the <see cref="GedcomxDateRange"/> range of the current recurrences.
-    /// </summary>
-    /// <value>
-    /// The range.
-    /// </value>
-    public GedcomxDateRange Range
-    {
-      get
-      {
-        return range;
-      }
-    }
+		/// <summary>
+		/// Gets the <see cref="GedcomxDateRange"/> range of the current recurrences.
+		/// </summary>
+		/// <value>
+		/// The range.
+		/// </value>
+		public GedcomxDateRange Range
+		{
+			get
+			{
+				return range;
+			}
+		}
 
-    /// <summary>
-    /// Gets the simple start date of the recurring period.
-    /// </summary>
-    /// <value>
-    /// The simple start date of the recurring period.
-    /// </value>
-    public GedcomxDateSimple Start
-    {
-      get
-      {
-        return range.Start;
-      }
-    }
+		/// <summary>
+		/// Gets the simple start date of the recurring period.
+		/// </summary>
+		/// <value>
+		/// The simple start date of the recurring period.
+		/// </value>
+		public GedcomxDateSimple Start
+		{
+			get
+			{
+				return range.Start;
+			}
+		}
 
-    /// <summary>
-    /// Gets the <see cref="GedcomxDateDuration"/> of the recurring period.
-    /// </summary>
-    /// <value>
-    /// The the <see cref="GedcomxDateDuration"/> of the recurring period.
-    /// </value>
-    public GedcomxDateDuration Duration
-    {
-      get
-      {
-        return range.Duration;
-      }
-    }
+		/// <summary>
+		/// Gets the <see cref="GedcomxDateDuration"/> of the recurring period.
+		/// </summary>
+		/// <value>
+		/// The the <see cref="GedcomxDateDuration"/> of the recurring period.
+		/// </value>
+		public GedcomxDateDuration Duration
+		{
+			get
+			{
+				return range.Duration;
+			}
+		}
 
-    /// <summary>
-    /// Gets the simple end date of the recurring period.
-    /// </summary>
-    /// <value>
-    /// The simple end date of the recurring period.
-    /// </value>
-    public GedcomxDateSimple End
-    {
-      get
-      {
-        return end;
-      }
-    }
+		/// <summary>
+		/// Gets the simple end date of the recurring period.
+		/// </summary>
+		/// <value>
+		/// The simple end date of the recurring period.
+		/// </value>
+		public GedcomxDateSimple End
+		{
+			get
+			{
+				return end;
+			}
+		}
 
-    /// <summary>
-    /// Gets the nth instance of this recurring date.
-    /// </summary>
-    /// <param name="count">The nth instance to retrieve.</param>
-    /// <returns>The simple date of the nth instance.</returns>
-    public GedcomxDateSimple GetNth(Int32 count)
-    {
-      GedcomxDateDuration duration = GedcomxDateUtil.MultiplyDuration(range.Duration, count);
+		/// <summary>
+		/// Gets the nth instance of this recurring date.
+		/// </summary>
+		/// <param name="count">The nth instance to retrieve.</param>
+		/// <returns>The simple date of the nth instance.</returns>
+		public GedcomxDateSimple GetNth(Int32 count)
+		{
+			GedcomxDateDuration duration = GedcomxDateUtil.MultiplyDuration(range.Duration, count);
 
-      return GedcomxDateUtil.AddDuration(range.Start, duration);
-    }
+			return GedcomxDateUtil.AddDuration(range.Start, duration);
+		}
 
-    /// <summary>
-    /// Gets the type of GEDCOM X date. This property always returns RECURRING for this instance.
-    /// </summary>
-    /// <value>
-    /// The type of GEDCOM X date.
-    /// </value>
-    public override GedcomxDateType Type
-    {
-      get
-      {
-        return GedcomxDateType.RECURRING;
-      }
-    }
+		/// <summary>
+		/// Gets the type of GEDCOM X date. This property always returns RECURRING for this instance.
+		/// </summary>
+		/// <value>
+		/// The type of GEDCOM X date.
+		/// </value>
+		public override GedcomxDateType Type
+		{
+			get
+			{
+				return GedcomxDateType.RECURRING;
+			}
+		}
 
-    /// <summary>
-    /// Determines whether this date is approximate. This method always returns <c>false</c> for this instance.
-    /// </summary>
-    /// <value>
-    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-    /// </value>
-    public override bool IsApproximate
-    {
-      get
-      {
-        return false;
-      }
-    }
+		/// <summary>
+		/// Determines whether this date is approximate. This method always returns <c>false</c> for this instance.
+		/// </summary>
+		/// <value>
+		///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+		/// </value>
+		public override bool IsApproximate
+		{
+			get
+			{
+				return false;
+			}
+		}
 
-    /// <summary>
-    /// The formal representation of this date.
-    /// </summary>
-    /// <value>
-    /// The formal representation of this date.
-    /// </value>
-    public override String FormalString
-    {
-      get
-      {
-        if (count != null)
-        {
-          return "R" + count + "/" + range.FormalString;
-        }
-        else
-        {
-          return "R/" + range.FormalString;
-        }
-      }
-    }
-  }
+		/// <summary>
+		/// The formal representation of this date.
+		/// </summary>
+		/// <value>
+		/// The formal representation of this date.
+		/// </value>
+		public override String FormalString
+		{
+			get
+			{
+				if (count != null)
+				{
+					return "R" + count + "/" + range.FormalString;
+				}
+				else
+				{
+					return "R/" + range.FormalString;
+				}
+			}
+		}
+	}
 }

--- a/GEDCOM X Date/GedcomxDateRecurring.cs
+++ b/GEDCOM X Date/GedcomxDateRecurring.cs
@@ -5,207 +5,207 @@ using System.Text;
 
 namespace Gedcomx.Date
 {
-	/// <summary>
-	/// Represents a recurring GEDCOM X date.
-	/// </summary>
-	public class GedcomxDateRecurring : GedcomxDate
-	{
+  /// <summary>
+  /// Represents a recurring GEDCOM X date.
+  /// </summary>
+  public class GedcomxDateRecurring : GedcomxDate
+  {
 
-		private Int32? count = null;
-		private GedcomxDateRange range;
-		private GedcomxDateSimple end = null;
+    private Int32? count = null;
+    private GedcomxDateRange range;
+    private GedcomxDateSimple end = null;
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="GedcomxDateRecurring"/> class.
-		/// </summary>
-		/// <param name="date">The recurring date string that describes a recurring GEDCOM X date.</param>
-		/// <exception cref="Gedcomx.Date.GedcomxDateException">
-		/// Thrown if the formal date string is null, empty, or fails to meet the expected format. The specific reason will be given at runtime.
-		/// </exception>
-		public GedcomxDateRecurring(String date)
-		{
-			if (date == null || date.Length < 3)
-			{
-				throw new GedcomxDateException("Invalid Recurring Date");
-			}
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GedcomxDateRecurring"/> class.
+    /// </summary>
+    /// <param name="date">The recurring date string that describes a recurring GEDCOM X date.</param>
+    /// <exception cref="Gedcomx.Date.GedcomxDateException">
+    /// Thrown if the formal date string is null, empty, or fails to meet the expected format. The specific reason will be given at runtime.
+    /// </exception>
+    public GedcomxDateRecurring(String date)
+    {
+      if (date == null || date.Length < 3)
+      {
+        throw new GedcomxDateException("Invalid Recurring Date");
+      }
 
-			if (date[0] != 'R')
-			{
-				throw new GedcomxDateException("Invalid Recurring Date: Must start with R");
-			}
+      if (date[0] != 'R')
+      {
+        throw new GedcomxDateException("Invalid Recurring Date: Must start with R");
+      }
 
-			String[] parts = date.Split('/');
+      String[] parts = date.Split('/');
 
-			if (parts.Length != 3)
-			{
-				throw new GedcomxDateException("Invalid Recurring Date: Must contain 3 parts");
-			}
+      if (parts.Length != 3)
+      {
+        throw new GedcomxDateException("Invalid Recurring Date: Must contain 3 parts");
+      }
 
-			// We must have a start and end
-			if (parts[1].Equals("") || parts[2].Equals(""))
-			{
-				throw new GedcomxDateException("Invalid Recurring Date: Range must have a start and an end");
-			}
+      // We must have a start and end
+      if (parts[1].Equals("") || parts[2].Equals(""))
+      {
+        throw new GedcomxDateException("Invalid Recurring Date: Range must have a start and an end");
+      }
 
-			String countNum = parts[0].Substring(1);
-			char[] countNumChars = parts[0].Substring(1).ToCharArray();
+      String countNum = parts[0].Substring(1);
+      char[] countNumChars = parts[0].Substring(1).ToCharArray();
 
-			if (countNumChars.Length > 0)
-			{
-				foreach (char c in countNumChars)
-				{
-					if (!Char.IsDigit(c))
-					{
-						throw new GedcomxDateException("Invalid Recurring Date: Malformed Count");
-					}
-				}
-				count = Int32.Parse(countNum);
-			}
-			try
-			{
-				range = new GedcomxDateRange(parts[1] + "/" + parts[2]);
-			}
-			catch (GedcomxDateException e)
-			{
-				throw new GedcomxDateException(e.Message + " in Recurring Range");
-			}
+      if (countNumChars.Length > 0)
+      {
+        foreach (char c in countNumChars)
+        {
+          if (!Char.IsDigit(c))
+          {
+            throw new GedcomxDateException("Invalid Recurring Date: Malformed Count");
+          }
+        }
+        count = Int32.Parse(countNum);
+      }
+      try
+      {
+        range = new GedcomxDateRange(parts[1] + "/" + parts[2]);
+      }
+      catch (GedcomxDateException e)
+      {
+        throw new GedcomxDateException(e.Message + " in Recurring Range");
+      }
 
-			// If we have a count set end
-			if (count != null)
-			{
-				end = GetNth(count.Value);
-			}
-		}
+      // If we have a count set end
+      if (count != null)
+      {
+        end = GetNth(count.Value);
+      }
+    }
 
-		/// <summary>
-		/// Gets the count of recurring instances if applicable.
-		/// </summary>
-		/// <value>
-		/// The count of recurring instances if applicable.
-		/// </value>
-		public Int32? Count
-		{
-			get
-			{
-				return count;
-			}
-		}
+    /// <summary>
+    /// Gets the count of recurring instances if applicable.
+    /// </summary>
+    /// <value>
+    /// The count of recurring instances if applicable.
+    /// </value>
+    public Int32? Count
+    {
+      get
+      {
+        return count;
+      }
+    }
 
-		/// <summary>
-		/// Gets the <see cref="GedcomxDateRange"/> range of the current recurrences.
-		/// </summary>
-		/// <value>
-		/// The range.
-		/// </value>
-		public GedcomxDateRange Range
-		{
-			get
-			{
-				return range;
-			}
-		}
+    /// <summary>
+    /// Gets the <see cref="GedcomxDateRange"/> range of the current recurrences.
+    /// </summary>
+    /// <value>
+    /// The range.
+    /// </value>
+    public GedcomxDateRange Range
+    {
+      get
+      {
+        return range;
+      }
+    }
 
-		/// <summary>
-		/// Gets the simple start date of the recurring period.
-		/// </summary>
-		/// <value>
-		/// The simple start date of the recurring period.
-		/// </value>
-		public GedcomxDateSimple Start
-		{
-			get
-			{
-				return range.Start;
-			}
-		}
+    /// <summary>
+    /// Gets the simple start date of the recurring period.
+    /// </summary>
+    /// <value>
+    /// The simple start date of the recurring period.
+    /// </value>
+    public GedcomxDateSimple Start
+    {
+      get
+      {
+        return range.Start;
+      }
+    }
 
-		/// <summary>
-		/// Gets the <see cref="GedcomxDateDuration"/> of the recurring period.
-		/// </summary>
-		/// <value>
-		/// The the <see cref="GedcomxDateDuration"/> of the recurring period.
-		/// </value>
-		public GedcomxDateDuration Duration
-		{
-			get
-			{
-				return range.Duration;
-			}
-		}
+    /// <summary>
+    /// Gets the <see cref="GedcomxDateDuration"/> of the recurring period.
+    /// </summary>
+    /// <value>
+    /// The the <see cref="GedcomxDateDuration"/> of the recurring period.
+    /// </value>
+    public GedcomxDateDuration Duration
+    {
+      get
+      {
+        return range.Duration;
+      }
+    }
 
-		/// <summary>
-		/// Gets the simple end date of the recurring period.
-		/// </summary>
-		/// <value>
-		/// The simple end date of the recurring period.
-		/// </value>
-		public GedcomxDateSimple End
-		{
-			get
-			{
-				return end;
-			}
-		}
+    /// <summary>
+    /// Gets the simple end date of the recurring period.
+    /// </summary>
+    /// <value>
+    /// The simple end date of the recurring period.
+    /// </value>
+    public GedcomxDateSimple End
+    {
+      get
+      {
+        return end;
+      }
+    }
 
-		/// <summary>
-		/// Gets the nth instance of this recurring date.
-		/// </summary>
-		/// <param name="count">The nth instance to retrieve.</param>
-		/// <returns>The simple date of the nth instance.</returns>
-		public GedcomxDateSimple GetNth(Int32 count)
-		{
-			GedcomxDateDuration duration = GedcomxDateUtil.MultiplyDuration(range.Duration, count);
+    /// <summary>
+    /// Gets the nth instance of this recurring date.
+    /// </summary>
+    /// <param name="count">The nth instance to retrieve.</param>
+    /// <returns>The simple date of the nth instance.</returns>
+    public GedcomxDateSimple GetNth(Int32 count)
+    {
+      GedcomxDateDuration duration = GedcomxDateUtil.MultiplyDuration(range.Duration, count);
 
-			return GedcomxDateUtil.AddDuration(range.Start, duration);
-		}
+      return GedcomxDateUtil.AddDuration(range.Start, duration);
+    }
 
-		/// <summary>
-		/// Gets the type of GEDCOM X date. This property always returns RECURRING for this instance.
-		/// </summary>
-		/// <value>
-		/// The type of GEDCOM X date.
-		/// </value>
-		public override GedcomxDateType Type
-		{
-			get
-			{
-				return GedcomxDateType.RECURRING;
-			}
-		}
+    /// <summary>
+    /// Gets the type of GEDCOM X date. This property always returns RECURRING for this instance.
+    /// </summary>
+    /// <value>
+    /// The type of GEDCOM X date.
+    /// </value>
+    public override GedcomxDateType Type
+    {
+      get
+      {
+        return GedcomxDateType.RECURRING;
+      }
+    }
 
-		/// <summary>
-		/// Determines whether this date is approximate. This method always returns <c>false</c> for this instance.
-		/// </summary>
-		/// <value>
-		///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-		/// </value>
-		public override bool IsApproximate
-		{
-			get
-			{
-				return false;
-			}
-		}
+    /// <summary>
+    /// Determines whether this date is approximate. This method always returns <c>false</c> for this instance.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+    /// </value>
+    public override bool IsApproximate
+    {
+      get
+      {
+        return false;
+      }
+    }
 
-		/// <summary>
-		/// The formal representation of this date.
-		/// </summary>
-		/// <value>
-		/// The formal representation of this date.
-		/// </value>
-		public override String FormalString
-		{
-			get
-			{
-				if (count != null)
-				{
-					return "R" + count + "/" + range.FormalString;
-				}
-				else
-				{
-					return "R/" + range.FormalString;
-				}
-			}
-		}
-	}
+    /// <summary>
+    /// The formal representation of this date.
+    /// </summary>
+    /// <value>
+    /// The formal representation of this date.
+    /// </value>
+    public override String FormalString
+    {
+      get
+      {
+        if (count != null)
+        {
+          return "R" + count + "/" + range.FormalString;
+        }
+        else
+        {
+          return "R/" + range.FormalString;
+        }
+      }
+    }
+  }
 }

--- a/GEDCOM X Date/GedcomxDateRecurring.cs
+++ b/GEDCOM X Date/GedcomxDateRecurring.cs
@@ -5,201 +5,207 @@ using System.Text;
 
 namespace Gedcomx.Date
 {
+  /// <summary>
+  /// Represents a recurring GEDCOM X date.
+  /// </summary>
+  public class GedcomxDateRecurring : GedcomxDate
+  {
+
+    private Int32? count = null;
+    private GedcomxDateRange range;
+    private GedcomxDateSimple end = null;
+
     /// <summary>
-    /// Represents a recurring GEDCOM X date.
+    /// Initializes a new instance of the <see cref="GedcomxDateRecurring"/> class.
     /// </summary>
-    public class GedcomxDateRecurring : GedcomxDate
+    /// <param name="date">The recurring date string that describes a recurring GEDCOM X date.</param>
+    /// <exception cref="Gedcomx.Date.GedcomxDateException">
+    /// Thrown if the formal date string is null, empty, or fails to meet the expected format. The specific reason will be given at runtime.
+    /// </exception>
+    public GedcomxDateRecurring(String date)
     {
+      if (date == null || date.Length < 3)
+      {
+        throw new GedcomxDateException("Invalid Recurring Date");
+      }
 
-        private Int32? count = null;
-        private GedcomxDateRange range;
-        private GedcomxDateSimple end = null;
+      if (date[0] != 'R')
+      {
+        throw new GedcomxDateException("Invalid Recurring Date: Must start with R");
+      }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GedcomxDateRecurring"/> class.
-        /// </summary>
-        /// <param name="date">The recurring date string that describes a recurring GEDCOM X date.</param>
-        /// <exception cref="Gedcomx.Date.GedcomxDateException">
-        /// Thrown if the formal date string is null, empty, or fails to meet the expected format. The specific reason will be given at runtime.
-        /// </exception>
-        public GedcomxDateRecurring(String date)
+      String[] parts = date.Split('/');
+
+      if (parts.Length != 3)
+      {
+        throw new GedcomxDateException("Invalid Recurring Date: Must contain 3 parts");
+      }
+
+      // We must have a start and end
+      if (parts[1].Equals("") || parts[2].Equals(""))
+      {
+        throw new GedcomxDateException("Invalid Recurring Date: Range must have a start and an end");
+      }
+
+      String countNum = parts[0].Substring(1);
+      char[] countNumChars = parts[0].Substring(1).ToCharArray();
+
+      if (countNumChars.Length > 0)
+      {
+        foreach (char c in countNumChars)
         {
-            if (date == null || date.Length < 3)
-            {
-                throw new GedcomxDateException("Invalid Recurring Date");
-            }
-
-            if (date[0] != 'R')
-            {
-                throw new GedcomxDateException("Invalid Recurring Date: Must start with R");
-            }
-
-            String[] parts = date.Split('/');
-
-            if (parts.Length != 3)
-            {
-                throw new GedcomxDateException("Invalid Recurring Date: Must contain 3 parts");
-            }
-
-            // We must have a start and end
-            if (parts[1].Equals("") || parts[2].Equals(""))
-            {
-                throw new GedcomxDateException("Invalid Recurring Date: Range must have a start and an end");
-            }
-
-            String countNum = parts[0].Substring(1);
-            char[] countNumChars = parts[0].Substring(1).ToCharArray();
-
-            if (countNumChars.Length > 0)
-            {
-                foreach (char c in countNumChars)
-                {
-                    if (!Char.IsDigit(c))
-                    {
-                        throw new GedcomxDateException("Invalid Recurring Date: Malformed Count");
-                    }
-                }
-                count = Int32.Parse(countNum);
-            }
-            try
-            {
-                range = new GedcomxDateRange(parts[1] + "/" + parts[2]);
-            }
-            catch (GedcomxDateException e)
-            {
-                throw new GedcomxDateException(e.Message + " in Recurring Range");
-            }
-
-            // If we have a count set end
-            if (count != null)
-            {
-                end = GetNth(count.Value);
-            }
+          if (!Char.IsDigit(c))
+          {
+            throw new GedcomxDateException("Invalid Recurring Date: Malformed Count");
+          }
         }
+        count = Int32.Parse(countNum);
+      }
+      try
+      {
+        range = new GedcomxDateRange(parts[1] + "/" + parts[2]);
+      }
+      catch (GedcomxDateException e)
+      {
+        throw new GedcomxDateException(e.Message + " in Recurring Range");
+      }
 
-        /// <summary>
-        /// Gets the count of recurring instances if applicable.
-        /// </summary>
-        /// <value>
-        /// The count of recurring instances if applicable.
-        /// </value>
-        public Int32? Count
-        {
-            get
-            {
-                return count;
-            }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="GedcomxDateRange"/> range of the current recurrences.
-        /// </summary>
-        /// <value>
-        /// The range.
-        /// </value>
-        public GedcomxDateRange Range
-        {
-            get
-            {
-                return range;
-            }
-        }
-
-        /// <summary>
-        /// Gets the simple start date of the recurring period.
-        /// </summary>
-        /// <value>
-        /// The simple start date of the recurring period.
-        /// </value>
-        public GedcomxDateSimple Start
-        {
-            get
-            {
-                return range.Start;
-            }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="GedcomxDateDuration"/> of the recurring period.
-        /// </summary>
-        /// <value>
-        /// The the <see cref="GedcomxDateDuration"/> of the recurring period.
-        /// </value>
-        public GedcomxDateDuration Duration
-        {
-            get
-            {
-                return range.Duration;
-            }
-        }
-
-        /// <summary>
-        /// Gets the simple end date of the recurring period.
-        /// </summary>
-        /// <value>
-        /// The simple end date of the recurring period.
-        /// </value>
-        public GedcomxDateSimple End
-        {
-            get
-            {
-                return end;
-            }
-        }
-
-        /// <summary>
-        /// Gets the nth instance of this recurring date.
-        /// </summary>
-        /// <param name="count">The nth instance to retrieve.</param>
-        /// <returns>The simple date of the nth instance.</returns>
-        public GedcomxDateSimple GetNth(Int32 count)
-        {
-            GedcomxDateDuration duration = GedcomxDateUtil.MultiplyDuration(range.Duration, count);
-
-            return GedcomxDateUtil.AddDuration(range.Start, duration);
-        }
-
-        /// <summary>
-        /// Gets the type of GEDCOM X date. This property always returns RECURRING for this instance.
-        /// </summary>
-        /// <value>
-        /// The type of GEDCOM X date.
-        /// </value>
-        public override GedcomxDateType Type
-        {
-            get
-            {
-                return GedcomxDateType.RECURRING;
-            }
-        }
-
-        /// <summary>
-        /// Determines whether this date is approximate. This method always returns <c>false</c> for this instance.
-        /// </summary>
-        /// <returns>
-        ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-        /// </returns>
-        public override bool IsApproximate()
-        {
-            return false;
-        }
-
-        /// <summary>
-        /// The formal representation of this date.
-        /// </summary>
-        /// <returns>
-        /// The formal representation of this date.
-        /// </returns>
-        public override String ToFormalString()
-        {
-            if (count != null)
-            {
-                return "R" + count + "/" + range.ToFormalString();
-            }
-            else
-            {
-                return "R/" + range.ToFormalString();
-            }
-        }
+      // If we have a count set end
+      if (count != null)
+      {
+        end = GetNth(count.Value);
+      }
     }
+
+    /// <summary>
+    /// Gets the count of recurring instances if applicable.
+    /// </summary>
+    /// <value>
+    /// The count of recurring instances if applicable.
+    /// </value>
+    public Int32? Count
+    {
+      get
+      {
+        return count;
+      }
+    }
+
+    /// <summary>
+    /// Gets the <see cref="GedcomxDateRange"/> range of the current recurrences.
+    /// </summary>
+    /// <value>
+    /// The range.
+    /// </value>
+    public GedcomxDateRange Range
+    {
+      get
+      {
+        return range;
+      }
+    }
+
+    /// <summary>
+    /// Gets the simple start date of the recurring period.
+    /// </summary>
+    /// <value>
+    /// The simple start date of the recurring period.
+    /// </value>
+    public GedcomxDateSimple Start
+    {
+      get
+      {
+        return range.Start;
+      }
+    }
+
+    /// <summary>
+    /// Gets the <see cref="GedcomxDateDuration"/> of the recurring period.
+    /// </summary>
+    /// <value>
+    /// The the <see cref="GedcomxDateDuration"/> of the recurring period.
+    /// </value>
+    public GedcomxDateDuration Duration
+    {
+      get
+      {
+        return range.Duration;
+      }
+    }
+
+    /// <summary>
+    /// Gets the simple end date of the recurring period.
+    /// </summary>
+    /// <value>
+    /// The simple end date of the recurring period.
+    /// </value>
+    public GedcomxDateSimple End
+    {
+      get
+      {
+        return end;
+      }
+    }
+
+    /// <summary>
+    /// Gets the nth instance of this recurring date.
+    /// </summary>
+    /// <param name="count">The nth instance to retrieve.</param>
+    /// <returns>The simple date of the nth instance.</returns>
+    public GedcomxDateSimple GetNth(Int32 count)
+    {
+      GedcomxDateDuration duration = GedcomxDateUtil.MultiplyDuration(range.Duration, count);
+
+      return GedcomxDateUtil.AddDuration(range.Start, duration);
+    }
+
+    /// <summary>
+    /// Gets the type of GEDCOM X date. This property always returns RECURRING for this instance.
+    /// </summary>
+    /// <value>
+    /// The type of GEDCOM X date.
+    /// </value>
+    public override GedcomxDateType Type
+    {
+      get
+      {
+        return GedcomxDateType.RECURRING;
+      }
+    }
+
+    /// <summary>
+    /// Determines whether this date is approximate. This method always returns <c>false</c> for this instance.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+    /// </value>
+    public override bool IsApproximate
+    {
+      get
+      {
+        return false;
+      }
+    }
+
+    /// <summary>
+    /// The formal representation of this date.
+    /// </summary>
+    /// <value>
+    /// The formal representation of this date.
+    /// </value>
+    public override String FormalString
+    {
+      get
+      {
+        if (count != null)
+        {
+          return "R" + count + "/" + range.FormalString;
+        }
+        else
+        {
+          return "R/" + range.FormalString;
+        }
+      }
+    }
+  }
 }

--- a/GEDCOM X Date/GedcomxDateRecurring.cs
+++ b/GEDCOM X Date/GedcomxDateRecurring.cs
@@ -5,207 +5,207 @@ using System.Text;
 
 namespace Gedcomx.Date
 {
-  /// <summary>
-  /// Represents a recurring GEDCOM X date.
-  /// </summary>
-  public class GedcomxDateRecurring : GedcomxDate
-  {
-
-    private Int32? count = null;
-    private GedcomxDateRange range;
-    private GedcomxDateSimple end = null;
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="GedcomxDateRecurring"/> class.
+    /// Represents a recurring GEDCOM X date.
     /// </summary>
-    /// <param name="date">The recurring date string that describes a recurring GEDCOM X date.</param>
-    /// <exception cref="Gedcomx.Date.GedcomxDateException">
-    /// Thrown if the formal date string is null, empty, or fails to meet the expected format. The specific reason will be given at runtime.
-    /// </exception>
-    public GedcomxDateRecurring(String date)
+    public class GedcomxDateRecurring : GedcomxDate
     {
-      if (date == null || date.Length < 3)
-      {
-        throw new GedcomxDateException("Invalid Recurring Date");
-      }
 
-      if (date[0] != 'R')
-      {
-        throw new GedcomxDateException("Invalid Recurring Date: Must start with R");
-      }
+        private Int32? count = null;
+        private GedcomxDateRange range;
+        private GedcomxDateSimple end = null;
 
-      String[] parts = date.Split('/');
-
-      if (parts.Length != 3)
-      {
-        throw new GedcomxDateException("Invalid Recurring Date: Must contain 3 parts");
-      }
-
-      // We must have a start and end
-      if (parts[1].Equals("") || parts[2].Equals(""))
-      {
-        throw new GedcomxDateException("Invalid Recurring Date: Range must have a start and an end");
-      }
-
-      String countNum = parts[0].Substring(1);
-      char[] countNumChars = parts[0].Substring(1).ToCharArray();
-
-      if (countNumChars.Length > 0)
-      {
-        foreach (char c in countNumChars)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GedcomxDateRecurring"/> class.
+        /// </summary>
+        /// <param name="date">The recurring date string that describes a recurring GEDCOM X date.</param>
+        /// <exception cref="Gedcomx.Date.GedcomxDateException">
+        /// Thrown if the formal date string is null, empty, or fails to meet the expected format. The specific reason will be given at runtime.
+        /// </exception>
+        public GedcomxDateRecurring(String date)
         {
-          if (!Char.IsDigit(c))
-          {
-            throw new GedcomxDateException("Invalid Recurring Date: Malformed Count");
-          }
+            if (date == null || date.Length < 3)
+            {
+                throw new GedcomxDateException("Invalid Recurring Date");
+            }
+
+            if (date[0] != 'R')
+            {
+                throw new GedcomxDateException("Invalid Recurring Date: Must start with R");
+            }
+
+            String[] parts = date.Split('/');
+
+            if (parts.Length != 3)
+            {
+                throw new GedcomxDateException("Invalid Recurring Date: Must contain 3 parts");
+            }
+
+            // We must have a start and end
+            if (parts[1].Equals("") || parts[2].Equals(""))
+            {
+                throw new GedcomxDateException("Invalid Recurring Date: Range must have a start and an end");
+            }
+
+            String countNum = parts[0].Substring(1);
+            char[] countNumChars = parts[0].Substring(1).ToCharArray();
+
+            if (countNumChars.Length > 0)
+            {
+                foreach (char c in countNumChars)
+                {
+                    if (!Char.IsDigit(c))
+                    {
+                        throw new GedcomxDateException("Invalid Recurring Date: Malformed Count");
+                    }
+                }
+                count = Int32.Parse(countNum);
+            }
+            try
+            {
+                range = new GedcomxDateRange(parts[1] + "/" + parts[2]);
+            }
+            catch (GedcomxDateException e)
+            {
+                throw new GedcomxDateException(e.Message + " in Recurring Range");
+            }
+
+            // If we have a count set end
+            if (count != null)
+            {
+                end = GetNth(count.Value);
+            }
         }
-        count = Int32.Parse(countNum);
-      }
-      try
-      {
-        range = new GedcomxDateRange(parts[1] + "/" + parts[2]);
-      }
-      catch (GedcomxDateException e)
-      {
-        throw new GedcomxDateException(e.Message + " in Recurring Range");
-      }
 
-      // If we have a count set end
-      if (count != null)
-      {
-        end = GetNth(count.Value);
-      }
-    }
-
-    /// <summary>
-    /// Gets the count of recurring instances if applicable.
-    /// </summary>
-    /// <value>
-    /// The count of recurring instances if applicable.
-    /// </value>
-    public Int32? Count
-    {
-      get
-      {
-        return count;
-      }
-    }
-
-    /// <summary>
-    /// Gets the <see cref="GedcomxDateRange"/> range of the current recurrences.
-    /// </summary>
-    /// <value>
-    /// The range.
-    /// </value>
-    public GedcomxDateRange Range
-    {
-      get
-      {
-        return range;
-      }
-    }
-
-    /// <summary>
-    /// Gets the simple start date of the recurring period.
-    /// </summary>
-    /// <value>
-    /// The simple start date of the recurring period.
-    /// </value>
-    public GedcomxDateSimple Start
-    {
-      get
-      {
-        return range.Start;
-      }
-    }
-
-    /// <summary>
-    /// Gets the <see cref="GedcomxDateDuration"/> of the recurring period.
-    /// </summary>
-    /// <value>
-    /// The the <see cref="GedcomxDateDuration"/> of the recurring period.
-    /// </value>
-    public GedcomxDateDuration Duration
-    {
-      get
-      {
-        return range.Duration;
-      }
-    }
-
-    /// <summary>
-    /// Gets the simple end date of the recurring period.
-    /// </summary>
-    /// <value>
-    /// The simple end date of the recurring period.
-    /// </value>
-    public GedcomxDateSimple End
-    {
-      get
-      {
-        return end;
-      }
-    }
-
-    /// <summary>
-    /// Gets the nth instance of this recurring date.
-    /// </summary>
-    /// <param name="count">The nth instance to retrieve.</param>
-    /// <returns>The simple date of the nth instance.</returns>
-    public GedcomxDateSimple GetNth(Int32 count)
-    {
-      GedcomxDateDuration duration = GedcomxDateUtil.MultiplyDuration(range.Duration, count);
-
-      return GedcomxDateUtil.AddDuration(range.Start, duration);
-    }
-
-    /// <summary>
-    /// Gets the type of GEDCOM X date. This property always returns RECURRING for this instance.
-    /// </summary>
-    /// <value>
-    /// The type of GEDCOM X date.
-    /// </value>
-    public override GedcomxDateType Type
-    {
-      get
-      {
-        return GedcomxDateType.RECURRING;
-      }
-    }
-
-    /// <summary>
-    /// Determines whether this date is approximate. This method always returns <c>false</c> for this instance.
-    /// </summary>
-    /// <value>
-    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-    /// </value>
-    public override bool IsApproximate
-    {
-      get
-      {
-        return false;
-      }
-    }
-
-    /// <summary>
-    /// The formal representation of this date.
-    /// </summary>
-    /// <value>
-    /// The formal representation of this date.
-    /// </value>
-    public override String FormalString
-    {
-      get
-      {
-        if (count != null)
+        /// <summary>
+        /// Gets the count of recurring instances if applicable.
+        /// </summary>
+        /// <value>
+        /// The count of recurring instances if applicable.
+        /// </value>
+        public Int32? Count
         {
-          return "R" + count + "/" + range.FormalString;
+            get
+            {
+                return count;
+            }
         }
-        else
+
+        /// <summary>
+        /// Gets the <see cref="GedcomxDateRange"/> range of the current recurrences.
+        /// </summary>
+        /// <value>
+        /// The range.
+        /// </value>
+        public GedcomxDateRange Range
         {
-          return "R/" + range.FormalString;
+            get
+            {
+                return range;
+            }
         }
-      }
+
+        /// <summary>
+        /// Gets the simple start date of the recurring period.
+        /// </summary>
+        /// <value>
+        /// The simple start date of the recurring period.
+        /// </value>
+        public GedcomxDateSimple Start
+        {
+            get
+            {
+                return range.Start;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="GedcomxDateDuration"/> of the recurring period.
+        /// </summary>
+        /// <value>
+        /// The the <see cref="GedcomxDateDuration"/> of the recurring period.
+        /// </value>
+        public GedcomxDateDuration Duration
+        {
+            get
+            {
+                return range.Duration;
+            }
+        }
+
+        /// <summary>
+        /// Gets the simple end date of the recurring period.
+        /// </summary>
+        /// <value>
+        /// The simple end date of the recurring period.
+        /// </value>
+        public GedcomxDateSimple End
+        {
+            get
+            {
+                return end;
+            }
+        }
+
+        /// <summary>
+        /// Gets the nth instance of this recurring date.
+        /// </summary>
+        /// <param name="count">The nth instance to retrieve.</param>
+        /// <returns>The simple date of the nth instance.</returns>
+        public GedcomxDateSimple GetNth(Int32 count)
+        {
+            GedcomxDateDuration duration = GedcomxDateUtil.MultiplyDuration(range.Duration, count);
+
+            return GedcomxDateUtil.AddDuration(range.Start, duration);
+        }
+
+        /// <summary>
+        /// Gets the type of GEDCOM X date. This property always returns RECURRING for this instance.
+        /// </summary>
+        /// <value>
+        /// The type of GEDCOM X date.
+        /// </value>
+        public override GedcomxDateType Type
+        {
+            get
+            {
+                return GedcomxDateType.RECURRING;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether this date is approximate. This method always returns <c>false</c> for this instance.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+        /// </value>
+        public override bool IsApproximate
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// The formal representation of this date.
+        /// </summary>
+        /// <value>
+        /// The formal representation of this date.
+        /// </value>
+        public override String FormalString
+        {
+            get
+            {
+                if (count != null)
+                {
+                    return "R" + count + "/" + range.FormalString;
+                }
+                else
+                {
+                    return "R/" + range.FormalString;
+                }
+            }
+        }
     }
-  }
 }

--- a/GEDCOM X Date/GedcomxDateSimple.cs
+++ b/GEDCOM X Date/GedcomxDateSimple.cs
@@ -7,610 +7,610 @@ using System.Threading.Tasks;
 
 namespace Gedcomx.Date
 {
-	/// <summary>
-	/// Represents a simple GEDCOM X date.
-	/// </summary>
-	public class GedcomxDateSimple : GedcomxDate
-	{
-		private Int32? year = null;
-		private Int32? month = null;
-		private Int32? day = null;
-		private Int32? hours = null;
-		private Int32? minutes = null;
-		private Int32? seconds = null;
-		private Int32? tzHours = null;
-		private Int32? tzMinutes = null;
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="GedcomxDateSimple"/> class.
-		/// </summary>
-		/// <param name="date">The formal date string that describes a simple GEDCOM X date.</param>
-		public GedcomxDateSimple(String date)
-		{
-			ParseDate(date);
-		}
-
-		/// <summary>
-		/// Parses the date of the specified formal date string and loads the results into the current instance.
-		/// </summary>
-		/// <param name="date">The formal date string to parse.</param>
-		/// <exception cref="Gedcomx.Date.GedcomxDateException">
-		/// Thrown if the formal date string does not meet the expected format.
-		/// </exception>
-		private void ParseDate(String date)
-		{
-			// There is a minimum length of 5 characters
-			if (date.Length < 5)
-			{
-				throw new GedcomxDateException("Invalid Date: Must have at least [+-]YYYY");
-			}
-
-			int end = date.Length;
-			int offset = 0;
-			String num;
-
-			// Must start with a + or -
-			if (date[offset] != '+' && date[offset] != '-')
-			{
-				throw new GedcomxDateException("Invalid Date: Must begin with + or -");
-			}
-
-			offset++;
-			num = date[0] == '-' ? "-" : "";
-			for (int i = 0; i < 4; i++)
-			{
-				if (!Char.IsDigit(date[offset]))
-				{
-					throw new GedcomxDateException("Invalid Date: Malformed Year");
-				}
-				num += date[offset++];
-			}
-
-			year = Int32.Parse(num);
-
-			if (offset == end)
-			{
-				return;
-			}
-
-			// If there is time
-			if (date[offset] == 'T')
-			{
-				ParseTime(date.Substring(offset + 1));
-				return;
-			}
-
-			// Month
-			if (date[offset] != '-')
-			{
-				throw new GedcomxDateException("Invalid Date: Invalid Year-Month Separator");
-			}
-
-			if (end - offset < 3)
-			{
-				throw new GedcomxDateException("Invalid Date: Month must be 2 digits");
-			}
-
-			offset++;
-			num = "";
-			for (int i = 0; i < 2; i++)
-			{
-				if (!Char.IsDigit(date[offset]))
-				{
-					throw new GedcomxDateException("Invalid Date: Malformed Month");
-				}
-				num += date[offset++];
-			}
-
-			month = Int32.Parse(num);
-
-			if (month < 1 || month > 12)
-			{
-				throw new GedcomxDateException("Invalid Date: Month must be between 1 and 12");
-			}
-
-			if (offset == end)
-			{
-				return;
-			}
-
-			// If there is time
-			if (date[offset] == 'T')
-			{
-				ParseTime(date.Substring(offset + 1));
-				return;
-			}
-
-			// Day
-			if (date[offset] != '-')
-			{
-				throw new GedcomxDateException("Invalid Date: Invalid Month-Day Separator");
-			}
-
-			if (end - offset < 3)
-			{
-				throw new GedcomxDateException("Invalid Date: Day must be 2 digits");
-			}
-
-			offset++;
-			num = "";
-			for (int i = 0; i < 2; i++)
-			{
-				if (!Char.IsDigit(date[offset]))
-				{
-					throw new GedcomxDateException("Invalid Date: Malformed Day");
-				}
-				num += date[offset++];
-			}
-
-			day = Int32.Parse(num);
-
-			if (day < 1)
-			{
-				throw new GedcomxDateException("Invalid Date: Day 0 does not exist");
-			}
-
-			int daysInMonth = DateTime.DaysInMonth(year.Value, month.Value);
-			if (day > daysInMonth)
-			{
-				throw new GedcomxDateException("Invalid Date: There are only " + daysInMonth + " days in Month " + month + " year " + year);
-			}
-
-			if (offset == end)
-			{
-				return;
-			}
-
-			if (date[offset] == 'T')
-			{
-				ParseTime(date.Substring(offset + 1));
-			}
-			else
-			{
-				throw new GedcomxDateException("Invalid Date: +YYYY-MM-DD must have T before time");
-			}
-
-		}
-
-		/// <summary>
-		/// Parses the time portion of the formal string
-		/// </summary>
-		/// <param name="date">The formal date string, excluding the date.</param>
-		/// <exception cref="Gedcomx.Date.GedcomxDateException">
-		/// Thrown if the formal date string does not meet the expected format. The specific reason will be given at runtime.
-		/// </exception>
-		private void ParseTime(String date)
-		{
-			int offset = 0;
-			int end = date.Length;
-			String num;
-			bool flag24 = false;
-
-			// Always initialize the Timezone to the local offset.
-			// It may be overridden if set
-			TimeZone tz = TimeZone.CurrentTimeZone;
-			double offsetInMillis = tz.GetUtcOffset(DateTime.Now).TotalMilliseconds;
-			tzHours = Convert.ToInt32(offsetInMillis / 3600000);
-			tzMinutes = Convert.ToInt32((offsetInMillis / 60000) % 60);
-
-			// You must at least have hours
-			if (end < 2)
-			{
-				throw new GedcomxDateException("Invalid Date: Hours must be 2 digits");
-			}
-
-			num = "";
-			for (int i = 0; i < 2; i++)
-			{
-				if (!Char.IsDigit(date[offset]))
-				{
-					throw new GedcomxDateException("Invalid Date: Malformed Hours");
-				}
-				num += date[offset++];
-			}
-
-			hours = Int32.Parse(num);
-
-			if (hours > 24)
-			{
-				throw new GedcomxDateException("Invalid Date: Hours must be between 0 and 24");
-			}
-
-			if (hours == 24)
-			{
-				flag24 = true;
-			}
-
-			if (offset == end)
-			{
-				return;
-			}
-
-			// If there is a timezone offset
-			if (date[offset] == '+' || date[offset] == '-' || date[offset] == 'Z')
-			{
-				ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
-				return;
-			}
-
-			if (date[offset] != ':')
-			{
-				throw new GedcomxDateException("Invalid Date: Invalid Hour-Minute Separator");
-			}
-
-			if (end - offset < 3)
-			{
-				throw new GedcomxDateException("Invalid Date: Minutes must be 2 digits");
-			}
-
-			offset++;
-			num = "";
-			for (int i = 0; i < 2; i++)
-			{
-				if (!Char.IsDigit(date[offset]))
-				{
-					throw new GedcomxDateException("Invalid Date: Malformed Minutes");
-				}
-				num += date[offset++];
-			}
-
-			minutes = Int32.Parse(num);
-
-			if (minutes > 59)
-			{
-				throw new GedcomxDateException("Invalid Date: Minutes must be between 0 and 59");
-			}
-
-			if (flag24 && minutes != 0)
-			{
-				throw new GedcomxDateException("Invalid Date: Hours of 24 requires 00 Minutes");
-			}
-
-			if (offset == end)
-			{
-				return;
-			}
-
-			// If there is a timezone offset
-			if (date[offset] == '+' || date[offset] == '-' || date[offset] == 'Z')
-			{
-				ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
-				return;
-			}
-
-			if (date[offset] != ':')
-			{
-				throw new GedcomxDateException("Invalid Date: Invalid Minute-Second Separator");
-			}
-
-			if (end - offset < 3)
-			{
-				throw new GedcomxDateException("Invalid Date: Seconds must be 2 digits");
-			}
-
-			offset++;
-			num = "";
-			for (int i = 0; i < 2; i++)
-			{
-				if (!Char.IsDigit(date[offset]))
-				{
-					throw new GedcomxDateException("Invalid Date: Malformed Seconds");
-				}
-				num += date[offset++];
-			}
-
-			seconds = Int32.Parse(num);
-
-			if (seconds > 59)
-			{
-				throw new GedcomxDateException("Invalid Date: Seconds must be between 0 and 59");
-			}
-
-			if (flag24 && seconds != 0)
-			{
-				throw new GedcomxDateException("Invalid Date: Hours of 24 requires 00 Seconds");
-			}
-
-			if (offset == end)
-			{
-				return;
-			}
-			else
-			{
-				ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
-			}
-
-		}
-
-		/**
-		 * Parse the timezone portion of the formal string
-		 * @param date The date string (minus the date and time)
-		 */
-		/// <summary>
-		/// Parses the timezone portion of the formal date string.
-		/// </summary>
-		/// <param name="date">The formal date string to parse (excluding the date and time).</param>
-		/// <exception cref="Gedcomx.Date.GedcomxDateException">
-		/// Thrown if the formal date string does not meet the expected format. The specific reason will be given at runtime.
-		/// </exception>
-		private void ParseTimezone(String date)
-		{
-			int offset = 0;
-			int end = date.Length;
-			String num;
-
-			// If Z we're done
-			if (date[offset] == 'Z')
-			{
-				if (end == 1)
-				{
-					tzHours = 0;
-					tzMinutes = 0;
-					return;
-				}
-				else
-				{
-					throw new GedcomxDateException("Invalid Date: Malformed Timezone - No Characters allowed after Z");
-				}
-			}
-
-			if (end - offset < 3)
-			{
-				throw new GedcomxDateException("Invalid Date: Malformed Timezone - tzHours must be [+-] followed by 2 digits");
-			}
-
-			// Must start with a + or -
-			if (date[offset] != '+' && date[offset] != '-')
-			{
-				throw new GedcomxDateException("Invalid Date: TimeZone Hours must begin with + or -");
-			}
-
-			offset++;
-			num = date[0] == '-' ? "-" : "";
-			for (int i = 0; i < 2; i++)
-			{
-				if (!Char.IsDigit(date[offset]))
-				{
-					throw new GedcomxDateException("Invalid Date: Malformed tzHours");
-				}
-				num += date[offset++];
-			}
-
-			tzHours = Int32.Parse(num);
-			// Set tzMinutes to clear out default local tz offset
-			tzMinutes = 0;
-
-			if (offset == end)
-			{
-				return;
-			}
-
-			if (date[offset] != ':')
-			{
-				throw new GedcomxDateException("Invalid Date: Invalid tzHour-tzMinute Separator");
-			}
-
-			if (end - offset < 3)
-			{
-				throw new GedcomxDateException("Invalid Date: tzSecond must be 2 digits");
-			}
-
-			offset++;
-			num = "";
-			for (int i = 0; i < 2; i++)
-			{
-				if (!Char.IsDigit(date[offset]))
-				{
-					throw new GedcomxDateException("Invalid Date: Malformed tzMinutes");
-				}
-				num += date[offset++];
-			}
-
-			tzMinutes = Int32.Parse(num);
-
-			if (offset == end)
-			{
-				return;
-			}
-			else
-			{
-				throw new GedcomxDateException("Invalid Date: Malformed Timezone - No characters allowed after tzSeconds");
-			}
-
-		}
-
-		/// <summary>
-		/// Gets the type of GEDCOM X date. This property always returns SIMPLE for this instance.
-		/// </summary>
-		/// <value>
-		/// The type of GEDCOM X date.
-		/// </value>
-		public override GedcomxDateType Type
-		{
-			get
-			{
-				return GedcomxDateType.SIMPLE;
-			}
-		}
-
-		/// <summary>
-		/// Determines whether this date is approximate. This method always returns <c>false</c> for this instance.
-		/// </summary>
-		/// <value>
-		///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-		/// </value>
-		public override bool IsApproximate
-		{
-			get
-			{
-				return false;
-			}
-		}
-
-		/// <summary>
-		/// The formal representation of this date.
-		/// </summary>
-		/// <value>
-		/// The formal representation of this date.
-		/// </value>
-		public override String FormalString
-		{
-			get
-			{
-				StringBuilder simple = new StringBuilder();
-
-				simple.Append(year >= 0 ? "+" : "-").Append(String.Format("{0:0000}", Math.Abs(year.Value)));
-
-				if (month != null)
-				{
-					simple.Append("-").Append(String.Format("{0:00}", month));
-				}
-
-				if (day != null)
-				{
-					simple.Append("-").Append(String.Format("{0:00}", day));
-				}
-
-				if (hours != null)
-				{
-					simple.Append("T").Append(String.Format("{0:00}", hours));
-
-					if (minutes != null)
-					{
-						simple.Append(":").Append(String.Format("{0:00}", minutes));
-					}
-
-					if (seconds != null)
-					{
-						simple.Append(":").Append(String.Format("{0:00}", seconds));
-					}
-
-					// If we have time we always have tz
-					if (tzHours == 0 && tzMinutes == 0)
-					{
-						simple.Append("Z");
-					}
-					else
-					{
-						simple.Append(tzHours >= 0 ? "+" : "-").Append(String.Format("{0:00}", Math.Abs(tzHours.Value)));
-						simple.Append(":").Append(String.Format("{0:00}", tzMinutes));
-					}
-				}
-
-				return simple.ToString();
-			}
-		}
-
-		/// <summary>
-		/// Gets the year of the current date if available.
-		/// </summary>
-		/// <value>
-		/// The year of the current date if available.
-		/// </value>
-		public Int32? Year
-		{
-			get
-			{
-				return year;
-			}
-		}
-
-		/// <summary>
-		/// Gets the month of the current date if available.
-		/// </summary>
-		/// <value>
-		/// The month of the current date if available.
-		/// </value>
-		public Int32? Month
-		{
-			get
-			{
-				return month;
-			}
-		}
-
-		/// <summary>
-		/// Gets the day of the current date if available.
-		/// </summary>
-		/// <value>
-		/// The day of the current date if available.
-		/// </value>
-		public Int32? Day
-		{
-			get
-			{
-				return day;
-			}
-		}
-
-		/// <summary>
-		/// Gets the hours of the current date if available.
-		/// </summary>
-		/// <value>
-		/// The hours of the current date if available.
-		/// </value>
-		public Int32? Hours
-		{
-			get
-			{
-				return hours;
-			}
-		}
-
-		/// <summary>
-		/// Gets the minutes of the current date if available.
-		/// </summary>
-		/// <value>
-		/// The minutes of the current date if available.
-		/// </value>
-		public Int32? Minutes
-		{
-			get
-			{
-				return minutes;
-			}
-		}
-
-		/// <summary>
-		/// Gets the seconds of the current date if available.
-		/// </summary>
-		/// <value>
-		/// The seconds of the current date if available.
-		/// </value>
-		public Int32? Seconds
-		{
-			get
-			{
-				return seconds;
-			}
-		}
-
-		/// <summary>
-		/// Gets the timezone hours of the current date if available.
-		/// </summary>
-		/// <value>
-		/// The timezone hours of the current date if available.
-		/// </value>
-		public Int32? TzHours
-		{
-			get
-			{
-				return tzHours;
-			}
-		}
-
-		/// <summary>
-		/// Gets the timezone minutes of the current date if available.
-		/// </summary>
-		/// <value>
-		/// The timezone minutes of the current date if available.
-		/// </value>
-		public Int32? TzMinutes
-		{
-			get
-			{
-				return tzMinutes;
-			}
-		}
-	}
+  /// <summary>
+  /// Represents a simple GEDCOM X date.
+  /// </summary>
+  public class GedcomxDateSimple : GedcomxDate
+  {
+    private Int32? year = null;
+    private Int32? month = null;
+    private Int32? day = null;
+    private Int32? hours = null;
+    private Int32? minutes = null;
+    private Int32? seconds = null;
+    private Int32? tzHours = null;
+    private Int32? tzMinutes = null;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GedcomxDateSimple"/> class.
+    /// </summary>
+    /// <param name="date">The formal date string that describes a simple GEDCOM X date.</param>
+    public GedcomxDateSimple(String date)
+    {
+      ParseDate(date);
+    }
+
+    /// <summary>
+    /// Parses the date of the specified formal date string and loads the results into the current instance.
+    /// </summary>
+    /// <param name="date">The formal date string to parse.</param>
+    /// <exception cref="Gedcomx.Date.GedcomxDateException">
+    /// Thrown if the formal date string does not meet the expected format.
+    /// </exception>
+    private void ParseDate(String date)
+    {
+      // There is a minimum length of 5 characters
+      if (date.Length < 5)
+      {
+        throw new GedcomxDateException("Invalid Date: Must have at least [+-]YYYY");
+      }
+
+      int end = date.Length;
+      int offset = 0;
+      String num;
+
+      // Must start with a + or -
+      if (date[offset] != '+' && date[offset] != '-')
+      {
+        throw new GedcomxDateException("Invalid Date: Must begin with + or -");
+      }
+
+      offset++;
+      num = date[0] == '-' ? "-" : "";
+      for (int i = 0; i < 4; i++)
+      {
+        if (!Char.IsDigit(date[offset]))
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed Year");
+        }
+        num += date[offset++];
+      }
+
+      year = Int32.Parse(num);
+
+      if (offset == end)
+      {
+        return;
+      }
+
+      // If there is time
+      if (date[offset] == 'T')
+      {
+        ParseTime(date.Substring(offset + 1));
+        return;
+      }
+
+      // Month
+      if (date[offset] != '-')
+      {
+        throw new GedcomxDateException("Invalid Date: Invalid Year-Month Separator");
+      }
+
+      if (end - offset < 3)
+      {
+        throw new GedcomxDateException("Invalid Date: Month must be 2 digits");
+      }
+
+      offset++;
+      num = "";
+      for (int i = 0; i < 2; i++)
+      {
+        if (!Char.IsDigit(date[offset]))
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed Month");
+        }
+        num += date[offset++];
+      }
+
+      month = Int32.Parse(num);
+
+      if (month < 1 || month > 12)
+      {
+        throw new GedcomxDateException("Invalid Date: Month must be between 1 and 12");
+      }
+
+      if (offset == end)
+      {
+        return;
+      }
+
+      // If there is time
+      if (date[offset] == 'T')
+      {
+        ParseTime(date.Substring(offset + 1));
+        return;
+      }
+
+      // Day
+      if (date[offset] != '-')
+      {
+        throw new GedcomxDateException("Invalid Date: Invalid Month-Day Separator");
+      }
+
+      if (end - offset < 3)
+      {
+        throw new GedcomxDateException("Invalid Date: Day must be 2 digits");
+      }
+
+      offset++;
+      num = "";
+      for (int i = 0; i < 2; i++)
+      {
+        if (!Char.IsDigit(date[offset]))
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed Day");
+        }
+        num += date[offset++];
+      }
+
+      day = Int32.Parse(num);
+
+      if (day < 1)
+      {
+        throw new GedcomxDateException("Invalid Date: Day 0 does not exist");
+      }
+
+      int daysInMonth = DateTime.DaysInMonth(year.Value, month.Value);
+      if (day > daysInMonth)
+      {
+        throw new GedcomxDateException("Invalid Date: There are only " + daysInMonth + " days in Month " + month + " year " + year);
+      }
+
+      if (offset == end)
+      {
+        return;
+      }
+
+      if (date[offset] == 'T')
+      {
+        ParseTime(date.Substring(offset + 1));
+      }
+      else
+      {
+        throw new GedcomxDateException("Invalid Date: +YYYY-MM-DD must have T before time");
+      }
+
+    }
+
+    /// <summary>
+    /// Parses the time portion of the formal string
+    /// </summary>
+    /// <param name="date">The formal date string, excluding the date.</param>
+    /// <exception cref="Gedcomx.Date.GedcomxDateException">
+    /// Thrown if the formal date string does not meet the expected format. The specific reason will be given at runtime.
+    /// </exception>
+    private void ParseTime(String date)
+    {
+      int offset = 0;
+      int end = date.Length;
+      String num;
+      bool flag24 = false;
+
+      // Always initialize the Timezone to the local offset.
+      // It may be overridden if set
+      TimeZone tz = TimeZone.CurrentTimeZone;
+      double offsetInMillis = tz.GetUtcOffset(DateTime.Now).TotalMilliseconds;
+      tzHours = Convert.ToInt32(offsetInMillis / 3600000);
+      tzMinutes = Convert.ToInt32((offsetInMillis / 60000) % 60);
+
+      // You must at least have hours
+      if (end < 2)
+      {
+        throw new GedcomxDateException("Invalid Date: Hours must be 2 digits");
+      }
+
+      num = "";
+      for (int i = 0; i < 2; i++)
+      {
+        if (!Char.IsDigit(date[offset]))
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed Hours");
+        }
+        num += date[offset++];
+      }
+
+      hours = Int32.Parse(num);
+
+      if (hours > 24)
+      {
+        throw new GedcomxDateException("Invalid Date: Hours must be between 0 and 24");
+      }
+
+      if (hours == 24)
+      {
+        flag24 = true;
+      }
+
+      if (offset == end)
+      {
+        return;
+      }
+
+      // If there is a timezone offset
+      if (date[offset] == '+' || date[offset] == '-' || date[offset] == 'Z')
+      {
+        ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
+        return;
+      }
+
+      if (date[offset] != ':')
+      {
+        throw new GedcomxDateException("Invalid Date: Invalid Hour-Minute Separator");
+      }
+
+      if (end - offset < 3)
+      {
+        throw new GedcomxDateException("Invalid Date: Minutes must be 2 digits");
+      }
+
+      offset++;
+      num = "";
+      for (int i = 0; i < 2; i++)
+      {
+        if (!Char.IsDigit(date[offset]))
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed Minutes");
+        }
+        num += date[offset++];
+      }
+
+      minutes = Int32.Parse(num);
+
+      if (minutes > 59)
+      {
+        throw new GedcomxDateException("Invalid Date: Minutes must be between 0 and 59");
+      }
+
+      if (flag24 && minutes != 0)
+      {
+        throw new GedcomxDateException("Invalid Date: Hours of 24 requires 00 Minutes");
+      }
+
+      if (offset == end)
+      {
+        return;
+      }
+
+      // If there is a timezone offset
+      if (date[offset] == '+' || date[offset] == '-' || date[offset] == 'Z')
+      {
+        ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
+        return;
+      }
+
+      if (date[offset] != ':')
+      {
+        throw new GedcomxDateException("Invalid Date: Invalid Minute-Second Separator");
+      }
+
+      if (end - offset < 3)
+      {
+        throw new GedcomxDateException("Invalid Date: Seconds must be 2 digits");
+      }
+
+      offset++;
+      num = "";
+      for (int i = 0; i < 2; i++)
+      {
+        if (!Char.IsDigit(date[offset]))
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed Seconds");
+        }
+        num += date[offset++];
+      }
+
+      seconds = Int32.Parse(num);
+
+      if (seconds > 59)
+      {
+        throw new GedcomxDateException("Invalid Date: Seconds must be between 0 and 59");
+      }
+
+      if (flag24 && seconds != 0)
+      {
+        throw new GedcomxDateException("Invalid Date: Hours of 24 requires 00 Seconds");
+      }
+
+      if (offset == end)
+      {
+        return;
+      }
+      else
+      {
+        ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
+      }
+
+    }
+
+    /**
+     * Parse the timezone portion of the formal string
+     * @param date The date string (minus the date and time)
+     */
+    /// <summary>
+    /// Parses the timezone portion of the formal date string.
+    /// </summary>
+    /// <param name="date">The formal date string to parse (excluding the date and time).</param>
+    /// <exception cref="Gedcomx.Date.GedcomxDateException">
+    /// Thrown if the formal date string does not meet the expected format. The specific reason will be given at runtime.
+    /// </exception>
+    private void ParseTimezone(String date)
+    {
+      int offset = 0;
+      int end = date.Length;
+      String num;
+
+      // If Z we're done
+      if (date[offset] == 'Z')
+      {
+        if (end == 1)
+        {
+          tzHours = 0;
+          tzMinutes = 0;
+          return;
+        }
+        else
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed Timezone - No Characters allowed after Z");
+        }
+      }
+
+      if (end - offset < 3)
+      {
+        throw new GedcomxDateException("Invalid Date: Malformed Timezone - tzHours must be [+-] followed by 2 digits");
+      }
+
+      // Must start with a + or -
+      if (date[offset] != '+' && date[offset] != '-')
+      {
+        throw new GedcomxDateException("Invalid Date: TimeZone Hours must begin with + or -");
+      }
+
+      offset++;
+      num = date[0] == '-' ? "-" : "";
+      for (int i = 0; i < 2; i++)
+      {
+        if (!Char.IsDigit(date[offset]))
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed tzHours");
+        }
+        num += date[offset++];
+      }
+
+      tzHours = Int32.Parse(num);
+      // Set tzMinutes to clear out default local tz offset
+      tzMinutes = 0;
+
+      if (offset == end)
+      {
+        return;
+      }
+
+      if (date[offset] != ':')
+      {
+        throw new GedcomxDateException("Invalid Date: Invalid tzHour-tzMinute Separator");
+      }
+
+      if (end - offset < 3)
+      {
+        throw new GedcomxDateException("Invalid Date: tzSecond must be 2 digits");
+      }
+
+      offset++;
+      num = "";
+      for (int i = 0; i < 2; i++)
+      {
+        if (!Char.IsDigit(date[offset]))
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed tzMinutes");
+        }
+        num += date[offset++];
+      }
+
+      tzMinutes = Int32.Parse(num);
+
+      if (offset == end)
+      {
+        return;
+      }
+      else
+      {
+        throw new GedcomxDateException("Invalid Date: Malformed Timezone - No characters allowed after tzSeconds");
+      }
+
+    }
+
+    /// <summary>
+    /// Gets the type of GEDCOM X date. This property always returns SIMPLE for this instance.
+    /// </summary>
+    /// <value>
+    /// The type of GEDCOM X date.
+    /// </value>
+    public override GedcomxDateType Type
+    {
+      get
+      {
+        return GedcomxDateType.SIMPLE;
+      }
+    }
+
+    /// <summary>
+    /// Determines whether this date is approximate. This method always returns <c>false</c> for this instance.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+    /// </value>
+    public override bool IsApproximate
+    {
+      get
+      {
+        return false;
+      }
+    }
+
+    /// <summary>
+    /// The formal representation of this date.
+    /// </summary>
+    /// <value>
+    /// The formal representation of this date.
+    /// </value>
+    public override String FormalString
+    {
+      get
+      {
+        StringBuilder simple = new StringBuilder();
+
+        simple.Append(year >= 0 ? "+" : "-").Append(String.Format("{0:0000}", Math.Abs(year.Value)));
+
+        if (month != null)
+        {
+          simple.Append("-").Append(String.Format("{0:00}", month));
+        }
+
+        if (day != null)
+        {
+          simple.Append("-").Append(String.Format("{0:00}", day));
+        }
+
+        if (hours != null)
+        {
+          simple.Append("T").Append(String.Format("{0:00}", hours));
+
+          if (minutes != null)
+          {
+            simple.Append(":").Append(String.Format("{0:00}", minutes));
+          }
+
+          if (seconds != null)
+          {
+            simple.Append(":").Append(String.Format("{0:00}", seconds));
+          }
+
+          // If we have time we always have tz
+          if (tzHours == 0 && tzMinutes == 0)
+          {
+            simple.Append("Z");
+          }
+          else
+          {
+            simple.Append(tzHours >= 0 ? "+" : "-").Append(String.Format("{0:00}", Math.Abs(tzHours.Value)));
+            simple.Append(":").Append(String.Format("{0:00}", tzMinutes));
+          }
+        }
+
+        return simple.ToString();
+      }
+    }
+
+    /// <summary>
+    /// Gets the year of the current date if available.
+    /// </summary>
+    /// <value>
+    /// The year of the current date if available.
+    /// </value>
+    public Int32? Year
+    {
+      get
+      {
+        return year;
+      }
+    }
+
+    /// <summary>
+    /// Gets the month of the current date if available.
+    /// </summary>
+    /// <value>
+    /// The month of the current date if available.
+    /// </value>
+    public Int32? Month
+    {
+      get
+      {
+        return month;
+      }
+    }
+
+    /// <summary>
+    /// Gets the day of the current date if available.
+    /// </summary>
+    /// <value>
+    /// The day of the current date if available.
+    /// </value>
+    public Int32? Day
+    {
+      get
+      {
+        return day;
+      }
+    }
+
+    /// <summary>
+    /// Gets the hours of the current date if available.
+    /// </summary>
+    /// <value>
+    /// The hours of the current date if available.
+    /// </value>
+    public Int32? Hours
+    {
+      get
+      {
+        return hours;
+      }
+    }
+
+    /// <summary>
+    /// Gets the minutes of the current date if available.
+    /// </summary>
+    /// <value>
+    /// The minutes of the current date if available.
+    /// </value>
+    public Int32? Minutes
+    {
+      get
+      {
+        return minutes;
+      }
+    }
+
+    /// <summary>
+    /// Gets the seconds of the current date if available.
+    /// </summary>
+    /// <value>
+    /// The seconds of the current date if available.
+    /// </value>
+    public Int32? Seconds
+    {
+      get
+      {
+        return seconds;
+      }
+    }
+
+    /// <summary>
+    /// Gets the timezone hours of the current date if available.
+    /// </summary>
+    /// <value>
+    /// The timezone hours of the current date if available.
+    /// </value>
+    public Int32? TzHours
+    {
+      get
+      {
+        return tzHours;
+      }
+    }
+
+    /// <summary>
+    /// Gets the timezone minutes of the current date if available.
+    /// </summary>
+    /// <value>
+    /// The timezone minutes of the current date if available.
+    /// </value>
+    public Int32? TzMinutes
+    {
+      get
+      {
+        return tzMinutes;
+      }
+    }
+  }
 }

--- a/GEDCOM X Date/GedcomxDateSimple.cs
+++ b/GEDCOM X Date/GedcomxDateSimple.cs
@@ -7,604 +7,610 @@ using System.Threading.Tasks;
 
 namespace Gedcomx.Date
 {
+  /// <summary>
+  /// Represents a simple GEDCOM X date.
+  /// </summary>
+  public class GedcomxDateSimple : GedcomxDate
+  {
+    private Int32? year = null;
+    private Int32? month = null;
+    private Int32? day = null;
+    private Int32? hours = null;
+    private Int32? minutes = null;
+    private Int32? seconds = null;
+    private Int32? tzHours = null;
+    private Int32? tzMinutes = null;
+
     /// <summary>
-    /// Represents a simple GEDCOM X date.
+    /// Initializes a new instance of the <see cref="GedcomxDateSimple"/> class.
     /// </summary>
-    public class GedcomxDateSimple : GedcomxDate
+    /// <param name="date">The formal date string that describes a simple GEDCOM X date.</param>
+    public GedcomxDateSimple(String date)
     {
-        private Int32? year = null;
-        private Int32? month = null;
-        private Int32? day = null;
-        private Int32? hours = null;
-        private Int32? minutes = null;
-        private Int32? seconds = null;
-        private Int32? tzHours = null;
-        private Int32? tzMinutes = null;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GedcomxDateSimple"/> class.
-        /// </summary>
-        /// <param name="date">The formal date string that describes a simple GEDCOM X date.</param>
-        public GedcomxDateSimple(String date)
-        {
-            ParseDate(date);
-        }
-
-        /// <summary>
-        /// Parses the date of the specified formal date string and loads the results into the current instance.
-        /// </summary>
-        /// <param name="date">The formal date string to parse.</param>
-        /// <exception cref="Gedcomx.Date.GedcomxDateException">
-        /// Thrown if the formal date string does not meet the expected format.
-        /// </exception>
-        private void ParseDate(String date)
-        {
-            // There is a minimum length of 5 characters
-            if (date.Length < 5)
-            {
-                throw new GedcomxDateException("Invalid Date: Must have at least [+-]YYYY");
-            }
-
-            int end = date.Length;
-            int offset = 0;
-            String num;
-
-            // Must start with a + or -
-            if (date[offset] != '+' && date[offset] != '-')
-            {
-                throw new GedcomxDateException("Invalid Date: Must begin with + or -");
-            }
-
-            offset++;
-            num = date[0] == '-' ? "-" : "";
-            for (int i = 0; i < 4; i++)
-            {
-                if (!Char.IsDigit(date[offset]))
-                {
-                    throw new GedcomxDateException("Invalid Date: Malformed Year");
-                }
-                num += date[offset++];
-            }
-
-            year = Int32.Parse(num);
-
-            if (offset == end)
-            {
-                return;
-            }
-
-            // If there is time
-            if (date[offset] == 'T')
-            {
-                ParseTime(date.Substring(offset + 1));
-                return;
-            }
-
-            // Month
-            if (date[offset] != '-')
-            {
-                throw new GedcomxDateException("Invalid Date: Invalid Year-Month Separator");
-            }
-
-            if (end - offset < 3)
-            {
-                throw new GedcomxDateException("Invalid Date: Month must be 2 digits");
-            }
-
-            offset++;
-            num = "";
-            for (int i = 0; i < 2; i++)
-            {
-                if (!Char.IsDigit(date[offset]))
-                {
-                    throw new GedcomxDateException("Invalid Date: Malformed Month");
-                }
-                num += date[offset++];
-            }
-
-            month = Int32.Parse(num);
-
-            if (month < 1 || month > 12)
-            {
-                throw new GedcomxDateException("Invalid Date: Month must be between 1 and 12");
-            }
-
-            if (offset == end)
-            {
-                return;
-            }
-
-            // If there is time
-            if (date[offset] == 'T')
-            {
-                ParseTime(date.Substring(offset + 1));
-                return;
-            }
-
-            // Day
-            if (date[offset] != '-')
-            {
-                throw new GedcomxDateException("Invalid Date: Invalid Month-Day Separator");
-            }
-
-            if (end - offset < 3)
-            {
-                throw new GedcomxDateException("Invalid Date: Day must be 2 digits");
-            }
-
-            offset++;
-            num = "";
-            for (int i = 0; i < 2; i++)
-            {
-                if (!Char.IsDigit(date[offset]))
-                {
-                    throw new GedcomxDateException("Invalid Date: Malformed Day");
-                }
-                num += date[offset++];
-            }
-
-            day = Int32.Parse(num);
-
-            if (day < 1)
-            {
-                throw new GedcomxDateException("Invalid Date: Day 0 does not exist");
-            }
-
-            int daysInMonth = DateTime.DaysInMonth(year.Value, month.Value);
-            if (day > daysInMonth)
-            {
-                throw new GedcomxDateException("Invalid Date: There are only " + daysInMonth + " days in Month " + month + " year " + year);
-            }
-
-            if (offset == end)
-            {
-                return;
-            }
-
-            if (date[offset] == 'T')
-            {
-                ParseTime(date.Substring(offset + 1));
-            }
-            else
-            {
-                throw new GedcomxDateException("Invalid Date: +YYYY-MM-DD must have T before time");
-            }
-
-        }
-
-        /// <summary>
-        /// Parses the time portion of the formal string
-        /// </summary>
-        /// <param name="date">The formal date string, excluding the date.</param>
-        /// <exception cref="Gedcomx.Date.GedcomxDateException">
-        /// Thrown if the formal date string does not meet the expected format. The specific reason will be given at runtime.
-        /// </exception>
-        private void ParseTime(String date)
-        {
-            int offset = 0;
-            int end = date.Length;
-            String num;
-            bool flag24 = false;
-
-            // Always initialize the Timezone to the local offset.
-            // It may be overridden if set
-            TimeZone tz = TimeZone.CurrentTimeZone;
-            double offsetInMillis = tz.GetUtcOffset(DateTime.Now).TotalMilliseconds;
-            tzHours = Convert.ToInt32(offsetInMillis / 3600000);
-            tzMinutes = Convert.ToInt32((offsetInMillis / 60000) % 60);
-
-            // You must at least have hours
-            if (end < 2)
-            {
-                throw new GedcomxDateException("Invalid Date: Hours must be 2 digits");
-            }
-
-            num = "";
-            for (int i = 0; i < 2; i++)
-            {
-                if (!Char.IsDigit(date[offset]))
-                {
-                    throw new GedcomxDateException("Invalid Date: Malformed Hours");
-                }
-                num += date[offset++];
-            }
-
-            hours = Int32.Parse(num);
-
-            if (hours > 24)
-            {
-                throw new GedcomxDateException("Invalid Date: Hours must be between 0 and 24");
-            }
-
-            if (hours == 24)
-            {
-                flag24 = true;
-            }
-
-            if (offset == end)
-            {
-                return;
-            }
-
-            // If there is a timezone offset
-            if (date[offset] == '+' || date[offset] == '-' || date[offset] == 'Z')
-            {
-                ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
-                return;
-            }
-
-            if (date[offset] != ':')
-            {
-                throw new GedcomxDateException("Invalid Date: Invalid Hour-Minute Separator");
-            }
-
-            if (end - offset < 3)
-            {
-                throw new GedcomxDateException("Invalid Date: Minutes must be 2 digits");
-            }
-
-            offset++;
-            num = "";
-            for (int i = 0; i < 2; i++)
-            {
-                if (!Char.IsDigit(date[offset]))
-                {
-                    throw new GedcomxDateException("Invalid Date: Malformed Minutes");
-                }
-                num += date[offset++];
-            }
-
-            minutes = Int32.Parse(num);
-
-            if (minutes > 59)
-            {
-                throw new GedcomxDateException("Invalid Date: Minutes must be between 0 and 59");
-            }
-
-            if (flag24 && minutes != 0)
-            {
-                throw new GedcomxDateException("Invalid Date: Hours of 24 requires 00 Minutes");
-            }
-
-            if (offset == end)
-            {
-                return;
-            }
-
-            // If there is a timezone offset
-            if (date[offset] == '+' || date[offset] == '-' || date[offset] == 'Z')
-            {
-                ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
-                return;
-            }
-
-            if (date[offset] != ':')
-            {
-                throw new GedcomxDateException("Invalid Date: Invalid Minute-Second Separator");
-            }
-
-            if (end - offset < 3)
-            {
-                throw new GedcomxDateException("Invalid Date: Seconds must be 2 digits");
-            }
-
-            offset++;
-            num = "";
-            for (int i = 0; i < 2; i++)
-            {
-                if (!Char.IsDigit(date[offset]))
-                {
-                    throw new GedcomxDateException("Invalid Date: Malformed Seconds");
-                }
-                num += date[offset++];
-            }
-
-            seconds = Int32.Parse(num);
-
-            if (seconds > 59)
-            {
-                throw new GedcomxDateException("Invalid Date: Seconds must be between 0 and 59");
-            }
-
-            if (flag24 && seconds != 0)
-            {
-                throw new GedcomxDateException("Invalid Date: Hours of 24 requires 00 Seconds");
-            }
-
-            if (offset == end)
-            {
-                return;
-            }
-            else
-            {
-                ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
-            }
-
-        }
-
-        /**
-         * Parse the timezone portion of the formal string
-         * @param date The date string (minus the date and time)
-         */
-        /// <summary>
-        /// Parses the timezone portion of the formal date string.
-        /// </summary>
-        /// <param name="date">The formal date string to parse (excluding the date and time).</param>
-        /// <exception cref="Gedcomx.Date.GedcomxDateException">
-        /// Thrown if the formal date string does not meet the expected format. The specific reason will be given at runtime.
-        /// </exception>
-        private void ParseTimezone(String date)
-        {
-            int offset = 0;
-            int end = date.Length;
-            String num;
-
-            // If Z we're done
-            if (date[offset] == 'Z')
-            {
-                if (end == 1)
-                {
-                    tzHours = 0;
-                    tzMinutes = 0;
-                    return;
-                }
-                else
-                {
-                    throw new GedcomxDateException("Invalid Date: Malformed Timezone - No Characters allowed after Z");
-                }
-            }
-
-            if (end - offset < 3)
-            {
-                throw new GedcomxDateException("Invalid Date: Malformed Timezone - tzHours must be [+-] followed by 2 digits");
-            }
-
-            // Must start with a + or -
-            if (date[offset] != '+' && date[offset] != '-')
-            {
-                throw new GedcomxDateException("Invalid Date: TimeZone Hours must begin with + or -");
-            }
-
-            offset++;
-            num = date[0] == '-' ? "-" : "";
-            for (int i = 0; i < 2; i++)
-            {
-                if (!Char.IsDigit(date[offset]))
-                {
-                    throw new GedcomxDateException("Invalid Date: Malformed tzHours");
-                }
-                num += date[offset++];
-            }
-
-            tzHours = Int32.Parse(num);
-            // Set tzMinutes to clear out default local tz offset
-            tzMinutes = 0;
-
-            if (offset == end)
-            {
-                return;
-            }
-
-            if (date[offset] != ':')
-            {
-                throw new GedcomxDateException("Invalid Date: Invalid tzHour-tzMinute Separator");
-            }
-
-            if (end - offset < 3)
-            {
-                throw new GedcomxDateException("Invalid Date: tzSecond must be 2 digits");
-            }
-
-            offset++;
-            num = "";
-            for (int i = 0; i < 2; i++)
-            {
-                if (!Char.IsDigit(date[offset]))
-                {
-                    throw new GedcomxDateException("Invalid Date: Malformed tzMinutes");
-                }
-                num += date[offset++];
-            }
-
-            tzMinutes = Int32.Parse(num);
-
-            if (offset == end)
-            {
-                return;
-            }
-            else
-            {
-                throw new GedcomxDateException("Invalid Date: Malformed Timezone - No characters allowed after tzSeconds");
-            }
-
-        }
-
-        /// <summary>
-        /// Gets the type of GEDCOM X date. This property always returns SIMPLE for this instance.
-        /// </summary>
-        /// <value>
-        /// The type of GEDCOM X date.
-        /// </value>
-        public override GedcomxDateType Type
-        {
-            get
-            {
-                return GedcomxDateType.SIMPLE;
-            }
-        }
-
-        /// <summary>
-        /// Determines whether this date is approximate. This method always returns <c>false</c> for this instance.
-        /// </summary>
-        /// <returns>
-        ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-        /// </returns>
-        public override bool IsApproximate()
-        {
-                return false;
-        }
-
-        /// <summary>
-        /// The formal representation of this date.
-        /// </summary>
-        /// <returns>
-        /// The formal representation of this date.
-        /// </returns>
-        public override String ToFormalString()
-        {
-            StringBuilder simple = new StringBuilder();
-
-            simple.Append(year >= 0 ? "+" : "-").Append(String.Format("{0:0000}", Math.Abs(year.Value)));
-
-            if (month != null)
-            {
-                simple.Append("-").Append(String.Format("{0:00}", month));
-            }
-
-            if (day != null)
-            {
-                simple.Append("-").Append(String.Format("{0:00}", day));
-            }
-
-            if (hours != null)
-            {
-                simple.Append("T").Append(String.Format("{0:00}", hours));
-
-                if (minutes != null)
-                {
-                    simple.Append(":").Append(String.Format("{0:00}", minutes));
-                }
-
-                if (seconds != null)
-                {
-                    simple.Append(":").Append(String.Format("{0:00}", seconds));
-                }
-
-                // If we have time we always have tz
-                if (tzHours == 0 && tzMinutes == 0)
-                {
-                    simple.Append("Z");
-                }
-                else
-                {
-                    simple.Append(tzHours >= 0 ? "+" : "-").Append(String.Format("{0:00}", Math.Abs(tzHours.Value)));
-                    simple.Append(":").Append(String.Format("{0:00}", tzMinutes));
-                }
-            }
-
-            return simple.ToString();
-        }
-
-        /// <summary>
-        /// Gets the year of the current date if available.
-        /// </summary>
-        /// <value>
-        /// The year of the current date if available.
-        /// </value>
-        public Int32? Year
-        {
-            get
-            {
-                return year;
-            }
-        }
-
-        /// <summary>
-        /// Gets the month of the current date if available.
-        /// </summary>
-        /// <value>
-        /// The month of the current date if available.
-        /// </value>
-        public Int32? Month
-        {
-            get
-            {
-                return month;
-            }
-        }
-
-        /// <summary>
-        /// Gets the day of the current date if available.
-        /// </summary>
-        /// <value>
-        /// The day of the current date if available.
-        /// </value>
-        public Int32? Day
-        {
-            get
-            {
-                return day;
-            }
-        }
-
-        /// <summary>
-        /// Gets the hours of the current date if available.
-        /// </summary>
-        /// <value>
-        /// The hours of the current date if available.
-        /// </value>
-        public Int32? Hours
-        {
-            get
-            {
-                return hours;
-            }
-        }
-
-        /// <summary>
-        /// Gets the minutes of the current date if available.
-        /// </summary>
-        /// <value>
-        /// The minutes of the current date if available.
-        /// </value>
-        public Int32? Minutes
-        {
-            get
-            {
-                return minutes;
-            }
-        }
-
-        /// <summary>
-        /// Gets the seconds of the current date if available.
-        /// </summary>
-        /// <value>
-        /// The seconds of the current date if available.
-        /// </value>
-        public Int32? Seconds
-        {
-            get
-            {
-                return seconds;
-            }
-        }
-
-        /// <summary>
-        /// Gets the timezone hours of the current date if available.
-        /// </summary>
-        /// <value>
-        /// The timezone hours of the current date if available.
-        /// </value>
-        public Int32? TzHours
-        {
-            get
-            {
-                return tzHours;
-            }
-        }
-
-        /// <summary>
-        /// Gets the timezone minutes of the current date if available.
-        /// </summary>
-        /// <value>
-        /// The timezone minutes of the current date if available.
-        /// </value>
-        public Int32? TzMinutes
-        {
-            get
-            {
-                return tzMinutes;
-            }
-        }
+      ParseDate(date);
     }
+
+    /// <summary>
+    /// Parses the date of the specified formal date string and loads the results into the current instance.
+    /// </summary>
+    /// <param name="date">The formal date string to parse.</param>
+    /// <exception cref="Gedcomx.Date.GedcomxDateException">
+    /// Thrown if the formal date string does not meet the expected format.
+    /// </exception>
+    private void ParseDate(String date)
+    {
+      // There is a minimum length of 5 characters
+      if (date.Length < 5)
+      {
+        throw new GedcomxDateException("Invalid Date: Must have at least [+-]YYYY");
+      }
+
+      int end = date.Length;
+      int offset = 0;
+      String num;
+
+      // Must start with a + or -
+      if (date[offset] != '+' && date[offset] != '-')
+      {
+        throw new GedcomxDateException("Invalid Date: Must begin with + or -");
+      }
+
+      offset++;
+      num = date[0] == '-' ? "-" : "";
+      for (int i = 0; i < 4; i++)
+      {
+        if (!Char.IsDigit(date[offset]))
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed Year");
+        }
+        num += date[offset++];
+      }
+
+      year = Int32.Parse(num);
+
+      if (offset == end)
+      {
+        return;
+      }
+
+      // If there is time
+      if (date[offset] == 'T')
+      {
+        ParseTime(date.Substring(offset + 1));
+        return;
+      }
+
+      // Month
+      if (date[offset] != '-')
+      {
+        throw new GedcomxDateException("Invalid Date: Invalid Year-Month Separator");
+      }
+
+      if (end - offset < 3)
+      {
+        throw new GedcomxDateException("Invalid Date: Month must be 2 digits");
+      }
+
+      offset++;
+      num = "";
+      for (int i = 0; i < 2; i++)
+      {
+        if (!Char.IsDigit(date[offset]))
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed Month");
+        }
+        num += date[offset++];
+      }
+
+      month = Int32.Parse(num);
+
+      if (month < 1 || month > 12)
+      {
+        throw new GedcomxDateException("Invalid Date: Month must be between 1 and 12");
+      }
+
+      if (offset == end)
+      {
+        return;
+      }
+
+      // If there is time
+      if (date[offset] == 'T')
+      {
+        ParseTime(date.Substring(offset + 1));
+        return;
+      }
+
+      // Day
+      if (date[offset] != '-')
+      {
+        throw new GedcomxDateException("Invalid Date: Invalid Month-Day Separator");
+      }
+
+      if (end - offset < 3)
+      {
+        throw new GedcomxDateException("Invalid Date: Day must be 2 digits");
+      }
+
+      offset++;
+      num = "";
+      for (int i = 0; i < 2; i++)
+      {
+        if (!Char.IsDigit(date[offset]))
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed Day");
+        }
+        num += date[offset++];
+      }
+
+      day = Int32.Parse(num);
+
+      if (day < 1)
+      {
+        throw new GedcomxDateException("Invalid Date: Day 0 does not exist");
+      }
+
+      int daysInMonth = DateTime.DaysInMonth(year.Value, month.Value);
+      if (day > daysInMonth)
+      {
+        throw new GedcomxDateException("Invalid Date: There are only " + daysInMonth + " days in Month " + month + " year " + year);
+      }
+
+      if (offset == end)
+      {
+        return;
+      }
+
+      if (date[offset] == 'T')
+      {
+        ParseTime(date.Substring(offset + 1));
+      }
+      else
+      {
+        throw new GedcomxDateException("Invalid Date: +YYYY-MM-DD must have T before time");
+      }
+
+    }
+
+    /// <summary>
+    /// Parses the time portion of the formal string
+    /// </summary>
+    /// <param name="date">The formal date string, excluding the date.</param>
+    /// <exception cref="Gedcomx.Date.GedcomxDateException">
+    /// Thrown if the formal date string does not meet the expected format. The specific reason will be given at runtime.
+    /// </exception>
+    private void ParseTime(String date)
+    {
+      int offset = 0;
+      int end = date.Length;
+      String num;
+      bool flag24 = false;
+
+      // Always initialize the Timezone to the local offset.
+      // It may be overridden if set
+      TimeZone tz = TimeZone.CurrentTimeZone;
+      double offsetInMillis = tz.GetUtcOffset(DateTime.Now).TotalMilliseconds;
+      tzHours = Convert.ToInt32(offsetInMillis / 3600000);
+      tzMinutes = Convert.ToInt32((offsetInMillis / 60000) % 60);
+
+      // You must at least have hours
+      if (end < 2)
+      {
+        throw new GedcomxDateException("Invalid Date: Hours must be 2 digits");
+      }
+
+      num = "";
+      for (int i = 0; i < 2; i++)
+      {
+        if (!Char.IsDigit(date[offset]))
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed Hours");
+        }
+        num += date[offset++];
+      }
+
+      hours = Int32.Parse(num);
+
+      if (hours > 24)
+      {
+        throw new GedcomxDateException("Invalid Date: Hours must be between 0 and 24");
+      }
+
+      if (hours == 24)
+      {
+        flag24 = true;
+      }
+
+      if (offset == end)
+      {
+        return;
+      }
+
+      // If there is a timezone offset
+      if (date[offset] == '+' || date[offset] == '-' || date[offset] == 'Z')
+      {
+        ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
+        return;
+      }
+
+      if (date[offset] != ':')
+      {
+        throw new GedcomxDateException("Invalid Date: Invalid Hour-Minute Separator");
+      }
+
+      if (end - offset < 3)
+      {
+        throw new GedcomxDateException("Invalid Date: Minutes must be 2 digits");
+      }
+
+      offset++;
+      num = "";
+      for (int i = 0; i < 2; i++)
+      {
+        if (!Char.IsDigit(date[offset]))
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed Minutes");
+        }
+        num += date[offset++];
+      }
+
+      minutes = Int32.Parse(num);
+
+      if (minutes > 59)
+      {
+        throw new GedcomxDateException("Invalid Date: Minutes must be between 0 and 59");
+      }
+
+      if (flag24 && minutes != 0)
+      {
+        throw new GedcomxDateException("Invalid Date: Hours of 24 requires 00 Minutes");
+      }
+
+      if (offset == end)
+      {
+        return;
+      }
+
+      // If there is a timezone offset
+      if (date[offset] == '+' || date[offset] == '-' || date[offset] == 'Z')
+      {
+        ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
+        return;
+      }
+
+      if (date[offset] != ':')
+      {
+        throw new GedcomxDateException("Invalid Date: Invalid Minute-Second Separator");
+      }
+
+      if (end - offset < 3)
+      {
+        throw new GedcomxDateException("Invalid Date: Seconds must be 2 digits");
+      }
+
+      offset++;
+      num = "";
+      for (int i = 0; i < 2; i++)
+      {
+        if (!Char.IsDigit(date[offset]))
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed Seconds");
+        }
+        num += date[offset++];
+      }
+
+      seconds = Int32.Parse(num);
+
+      if (seconds > 59)
+      {
+        throw new GedcomxDateException("Invalid Date: Seconds must be between 0 and 59");
+      }
+
+      if (flag24 && seconds != 0)
+      {
+        throw new GedcomxDateException("Invalid Date: Hours of 24 requires 00 Seconds");
+      }
+
+      if (offset == end)
+      {
+        return;
+      }
+      else
+      {
+        ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
+      }
+
+    }
+
+    /**
+     * Parse the timezone portion of the formal string
+     * @param date The date string (minus the date and time)
+     */
+    /// <summary>
+    /// Parses the timezone portion of the formal date string.
+    /// </summary>
+    /// <param name="date">The formal date string to parse (excluding the date and time).</param>
+    /// <exception cref="Gedcomx.Date.GedcomxDateException">
+    /// Thrown if the formal date string does not meet the expected format. The specific reason will be given at runtime.
+    /// </exception>
+    private void ParseTimezone(String date)
+    {
+      int offset = 0;
+      int end = date.Length;
+      String num;
+
+      // If Z we're done
+      if (date[offset] == 'Z')
+      {
+        if (end == 1)
+        {
+          tzHours = 0;
+          tzMinutes = 0;
+          return;
+        }
+        else
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed Timezone - No Characters allowed after Z");
+        }
+      }
+
+      if (end - offset < 3)
+      {
+        throw new GedcomxDateException("Invalid Date: Malformed Timezone - tzHours must be [+-] followed by 2 digits");
+      }
+
+      // Must start with a + or -
+      if (date[offset] != '+' && date[offset] != '-')
+      {
+        throw new GedcomxDateException("Invalid Date: TimeZone Hours must begin with + or -");
+      }
+
+      offset++;
+      num = date[0] == '-' ? "-" : "";
+      for (int i = 0; i < 2; i++)
+      {
+        if (!Char.IsDigit(date[offset]))
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed tzHours");
+        }
+        num += date[offset++];
+      }
+
+      tzHours = Int32.Parse(num);
+      // Set tzMinutes to clear out default local tz offset
+      tzMinutes = 0;
+
+      if (offset == end)
+      {
+        return;
+      }
+
+      if (date[offset] != ':')
+      {
+        throw new GedcomxDateException("Invalid Date: Invalid tzHour-tzMinute Separator");
+      }
+
+      if (end - offset < 3)
+      {
+        throw new GedcomxDateException("Invalid Date: tzSecond must be 2 digits");
+      }
+
+      offset++;
+      num = "";
+      for (int i = 0; i < 2; i++)
+      {
+        if (!Char.IsDigit(date[offset]))
+        {
+          throw new GedcomxDateException("Invalid Date: Malformed tzMinutes");
+        }
+        num += date[offset++];
+      }
+
+      tzMinutes = Int32.Parse(num);
+
+      if (offset == end)
+      {
+        return;
+      }
+      else
+      {
+        throw new GedcomxDateException("Invalid Date: Malformed Timezone - No characters allowed after tzSeconds");
+      }
+
+    }
+
+    /// <summary>
+    /// Gets the type of GEDCOM X date. This property always returns SIMPLE for this instance.
+    /// </summary>
+    /// <value>
+    /// The type of GEDCOM X date.
+    /// </value>
+    public override GedcomxDateType Type
+    {
+      get
+      {
+        return GedcomxDateType.SIMPLE;
+      }
+    }
+
+    /// <summary>
+    /// Determines whether this date is approximate. This method always returns <c>false</c> for this instance.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+    /// </value>
+    public override bool IsApproximate
+    {
+      get
+      {
+        return false;
+      }
+    }
+
+    /// <summary>
+    /// The formal representation of this date.
+    /// </summary>
+    /// <value>
+    /// The formal representation of this date.
+    /// </value>
+    public override String FormalString
+    {
+      get
+      {
+        StringBuilder simple = new StringBuilder();
+
+        simple.Append(year >= 0 ? "+" : "-").Append(String.Format("{0:0000}", Math.Abs(year.Value)));
+
+        if (month != null)
+        {
+          simple.Append("-").Append(String.Format("{0:00}", month));
+        }
+
+        if (day != null)
+        {
+          simple.Append("-").Append(String.Format("{0:00}", day));
+        }
+
+        if (hours != null)
+        {
+          simple.Append("T").Append(String.Format("{0:00}", hours));
+
+          if (minutes != null)
+          {
+            simple.Append(":").Append(String.Format("{0:00}", minutes));
+          }
+
+          if (seconds != null)
+          {
+            simple.Append(":").Append(String.Format("{0:00}", seconds));
+          }
+
+          // If we have time we always have tz
+          if (tzHours == 0 && tzMinutes == 0)
+          {
+            simple.Append("Z");
+          }
+          else
+          {
+            simple.Append(tzHours >= 0 ? "+" : "-").Append(String.Format("{0:00}", Math.Abs(tzHours.Value)));
+            simple.Append(":").Append(String.Format("{0:00}", tzMinutes));
+          }
+        }
+
+        return simple.ToString();
+      }
+    }
+
+    /// <summary>
+    /// Gets the year of the current date if available.
+    /// </summary>
+    /// <value>
+    /// The year of the current date if available.
+    /// </value>
+    public Int32? Year
+    {
+      get
+      {
+        return year;
+      }
+    }
+
+    /// <summary>
+    /// Gets the month of the current date if available.
+    /// </summary>
+    /// <value>
+    /// The month of the current date if available.
+    /// </value>
+    public Int32? Month
+    {
+      get
+      {
+        return month;
+      }
+    }
+
+    /// <summary>
+    /// Gets the day of the current date if available.
+    /// </summary>
+    /// <value>
+    /// The day of the current date if available.
+    /// </value>
+    public Int32? Day
+    {
+      get
+      {
+        return day;
+      }
+    }
+
+    /// <summary>
+    /// Gets the hours of the current date if available.
+    /// </summary>
+    /// <value>
+    /// The hours of the current date if available.
+    /// </value>
+    public Int32? Hours
+    {
+      get
+      {
+        return hours;
+      }
+    }
+
+    /// <summary>
+    /// Gets the minutes of the current date if available.
+    /// </summary>
+    /// <value>
+    /// The minutes of the current date if available.
+    /// </value>
+    public Int32? Minutes
+    {
+      get
+      {
+        return minutes;
+      }
+    }
+
+    /// <summary>
+    /// Gets the seconds of the current date if available.
+    /// </summary>
+    /// <value>
+    /// The seconds of the current date if available.
+    /// </value>
+    public Int32? Seconds
+    {
+      get
+      {
+        return seconds;
+      }
+    }
+
+    /// <summary>
+    /// Gets the timezone hours of the current date if available.
+    /// </summary>
+    /// <value>
+    /// The timezone hours of the current date if available.
+    /// </value>
+    public Int32? TzHours
+    {
+      get
+      {
+        return tzHours;
+      }
+    }
+
+    /// <summary>
+    /// Gets the timezone minutes of the current date if available.
+    /// </summary>
+    /// <value>
+    /// The timezone minutes of the current date if available.
+    /// </value>
+    public Int32? TzMinutes
+    {
+      get
+      {
+        return tzMinutes;
+      }
+    }
+  }
 }

--- a/GEDCOM X Date/GedcomxDateSimple.cs
+++ b/GEDCOM X Date/GedcomxDateSimple.cs
@@ -7,610 +7,610 @@ using System.Threading.Tasks;
 
 namespace Gedcomx.Date
 {
-  /// <summary>
-  /// Represents a simple GEDCOM X date.
-  /// </summary>
-  public class GedcomxDateSimple : GedcomxDate
-  {
-    private Int32? year = null;
-    private Int32? month = null;
-    private Int32? day = null;
-    private Int32? hours = null;
-    private Int32? minutes = null;
-    private Int32? seconds = null;
-    private Int32? tzHours = null;
-    private Int32? tzMinutes = null;
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="GedcomxDateSimple"/> class.
+    /// Represents a simple GEDCOM X date.
     /// </summary>
-    /// <param name="date">The formal date string that describes a simple GEDCOM X date.</param>
-    public GedcomxDateSimple(String date)
+    public class GedcomxDateSimple : GedcomxDate
     {
-      ParseDate(date);
-    }
+        private Int32? year = null;
+        private Int32? month = null;
+        private Int32? day = null;
+        private Int32? hours = null;
+        private Int32? minutes = null;
+        private Int32? seconds = null;
+        private Int32? tzHours = null;
+        private Int32? tzMinutes = null;
 
-    /// <summary>
-    /// Parses the date of the specified formal date string and loads the results into the current instance.
-    /// </summary>
-    /// <param name="date">The formal date string to parse.</param>
-    /// <exception cref="Gedcomx.Date.GedcomxDateException">
-    /// Thrown if the formal date string does not meet the expected format.
-    /// </exception>
-    private void ParseDate(String date)
-    {
-      // There is a minimum length of 5 characters
-      if (date.Length < 5)
-      {
-        throw new GedcomxDateException("Invalid Date: Must have at least [+-]YYYY");
-      }
-
-      int end = date.Length;
-      int offset = 0;
-      String num;
-
-      // Must start with a + or -
-      if (date[offset] != '+' && date[offset] != '-')
-      {
-        throw new GedcomxDateException("Invalid Date: Must begin with + or -");
-      }
-
-      offset++;
-      num = date[0] == '-' ? "-" : "";
-      for (int i = 0; i < 4; i++)
-      {
-        if (!Char.IsDigit(date[offset]))
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GedcomxDateSimple"/> class.
+        /// </summary>
+        /// <param name="date">The formal date string that describes a simple GEDCOM X date.</param>
+        public GedcomxDateSimple(String date)
         {
-          throw new GedcomxDateException("Invalid Date: Malformed Year");
-        }
-        num += date[offset++];
-      }
-
-      year = Int32.Parse(num);
-
-      if (offset == end)
-      {
-        return;
-      }
-
-      // If there is time
-      if (date[offset] == 'T')
-      {
-        ParseTime(date.Substring(offset + 1));
-        return;
-      }
-
-      // Month
-      if (date[offset] != '-')
-      {
-        throw new GedcomxDateException("Invalid Date: Invalid Year-Month Separator");
-      }
-
-      if (end - offset < 3)
-      {
-        throw new GedcomxDateException("Invalid Date: Month must be 2 digits");
-      }
-
-      offset++;
-      num = "";
-      for (int i = 0; i < 2; i++)
-      {
-        if (!Char.IsDigit(date[offset]))
-        {
-          throw new GedcomxDateException("Invalid Date: Malformed Month");
-        }
-        num += date[offset++];
-      }
-
-      month = Int32.Parse(num);
-
-      if (month < 1 || month > 12)
-      {
-        throw new GedcomxDateException("Invalid Date: Month must be between 1 and 12");
-      }
-
-      if (offset == end)
-      {
-        return;
-      }
-
-      // If there is time
-      if (date[offset] == 'T')
-      {
-        ParseTime(date.Substring(offset + 1));
-        return;
-      }
-
-      // Day
-      if (date[offset] != '-')
-      {
-        throw new GedcomxDateException("Invalid Date: Invalid Month-Day Separator");
-      }
-
-      if (end - offset < 3)
-      {
-        throw new GedcomxDateException("Invalid Date: Day must be 2 digits");
-      }
-
-      offset++;
-      num = "";
-      for (int i = 0; i < 2; i++)
-      {
-        if (!Char.IsDigit(date[offset]))
-        {
-          throw new GedcomxDateException("Invalid Date: Malformed Day");
-        }
-        num += date[offset++];
-      }
-
-      day = Int32.Parse(num);
-
-      if (day < 1)
-      {
-        throw new GedcomxDateException("Invalid Date: Day 0 does not exist");
-      }
-
-      int daysInMonth = DateTime.DaysInMonth(year.Value, month.Value);
-      if (day > daysInMonth)
-      {
-        throw new GedcomxDateException("Invalid Date: There are only " + daysInMonth + " days in Month " + month + " year " + year);
-      }
-
-      if (offset == end)
-      {
-        return;
-      }
-
-      if (date[offset] == 'T')
-      {
-        ParseTime(date.Substring(offset + 1));
-      }
-      else
-      {
-        throw new GedcomxDateException("Invalid Date: +YYYY-MM-DD must have T before time");
-      }
-
-    }
-
-    /// <summary>
-    /// Parses the time portion of the formal string
-    /// </summary>
-    /// <param name="date">The formal date string, excluding the date.</param>
-    /// <exception cref="Gedcomx.Date.GedcomxDateException">
-    /// Thrown if the formal date string does not meet the expected format. The specific reason will be given at runtime.
-    /// </exception>
-    private void ParseTime(String date)
-    {
-      int offset = 0;
-      int end = date.Length;
-      String num;
-      bool flag24 = false;
-
-      // Always initialize the Timezone to the local offset.
-      // It may be overridden if set
-      TimeZone tz = TimeZone.CurrentTimeZone;
-      double offsetInMillis = tz.GetUtcOffset(DateTime.Now).TotalMilliseconds;
-      tzHours = Convert.ToInt32(offsetInMillis / 3600000);
-      tzMinutes = Convert.ToInt32((offsetInMillis / 60000) % 60);
-
-      // You must at least have hours
-      if (end < 2)
-      {
-        throw new GedcomxDateException("Invalid Date: Hours must be 2 digits");
-      }
-
-      num = "";
-      for (int i = 0; i < 2; i++)
-      {
-        if (!Char.IsDigit(date[offset]))
-        {
-          throw new GedcomxDateException("Invalid Date: Malformed Hours");
-        }
-        num += date[offset++];
-      }
-
-      hours = Int32.Parse(num);
-
-      if (hours > 24)
-      {
-        throw new GedcomxDateException("Invalid Date: Hours must be between 0 and 24");
-      }
-
-      if (hours == 24)
-      {
-        flag24 = true;
-      }
-
-      if (offset == end)
-      {
-        return;
-      }
-
-      // If there is a timezone offset
-      if (date[offset] == '+' || date[offset] == '-' || date[offset] == 'Z')
-      {
-        ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
-        return;
-      }
-
-      if (date[offset] != ':')
-      {
-        throw new GedcomxDateException("Invalid Date: Invalid Hour-Minute Separator");
-      }
-
-      if (end - offset < 3)
-      {
-        throw new GedcomxDateException("Invalid Date: Minutes must be 2 digits");
-      }
-
-      offset++;
-      num = "";
-      for (int i = 0; i < 2; i++)
-      {
-        if (!Char.IsDigit(date[offset]))
-        {
-          throw new GedcomxDateException("Invalid Date: Malformed Minutes");
-        }
-        num += date[offset++];
-      }
-
-      minutes = Int32.Parse(num);
-
-      if (minutes > 59)
-      {
-        throw new GedcomxDateException("Invalid Date: Minutes must be between 0 and 59");
-      }
-
-      if (flag24 && minutes != 0)
-      {
-        throw new GedcomxDateException("Invalid Date: Hours of 24 requires 00 Minutes");
-      }
-
-      if (offset == end)
-      {
-        return;
-      }
-
-      // If there is a timezone offset
-      if (date[offset] == '+' || date[offset] == '-' || date[offset] == 'Z')
-      {
-        ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
-        return;
-      }
-
-      if (date[offset] != ':')
-      {
-        throw new GedcomxDateException("Invalid Date: Invalid Minute-Second Separator");
-      }
-
-      if (end - offset < 3)
-      {
-        throw new GedcomxDateException("Invalid Date: Seconds must be 2 digits");
-      }
-
-      offset++;
-      num = "";
-      for (int i = 0; i < 2; i++)
-      {
-        if (!Char.IsDigit(date[offset]))
-        {
-          throw new GedcomxDateException("Invalid Date: Malformed Seconds");
-        }
-        num += date[offset++];
-      }
-
-      seconds = Int32.Parse(num);
-
-      if (seconds > 59)
-      {
-        throw new GedcomxDateException("Invalid Date: Seconds must be between 0 and 59");
-      }
-
-      if (flag24 && seconds != 0)
-      {
-        throw new GedcomxDateException("Invalid Date: Hours of 24 requires 00 Seconds");
-      }
-
-      if (offset == end)
-      {
-        return;
-      }
-      else
-      {
-        ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
-      }
-
-    }
-
-    /**
-     * Parse the timezone portion of the formal string
-     * @param date The date string (minus the date and time)
-     */
-    /// <summary>
-    /// Parses the timezone portion of the formal date string.
-    /// </summary>
-    /// <param name="date">The formal date string to parse (excluding the date and time).</param>
-    /// <exception cref="Gedcomx.Date.GedcomxDateException">
-    /// Thrown if the formal date string does not meet the expected format. The specific reason will be given at runtime.
-    /// </exception>
-    private void ParseTimezone(String date)
-    {
-      int offset = 0;
-      int end = date.Length;
-      String num;
-
-      // If Z we're done
-      if (date[offset] == 'Z')
-      {
-        if (end == 1)
-        {
-          tzHours = 0;
-          tzMinutes = 0;
-          return;
-        }
-        else
-        {
-          throw new GedcomxDateException("Invalid Date: Malformed Timezone - No Characters allowed after Z");
-        }
-      }
-
-      if (end - offset < 3)
-      {
-        throw new GedcomxDateException("Invalid Date: Malformed Timezone - tzHours must be [+-] followed by 2 digits");
-      }
-
-      // Must start with a + or -
-      if (date[offset] != '+' && date[offset] != '-')
-      {
-        throw new GedcomxDateException("Invalid Date: TimeZone Hours must begin with + or -");
-      }
-
-      offset++;
-      num = date[0] == '-' ? "-" : "";
-      for (int i = 0; i < 2; i++)
-      {
-        if (!Char.IsDigit(date[offset]))
-        {
-          throw new GedcomxDateException("Invalid Date: Malformed tzHours");
-        }
-        num += date[offset++];
-      }
-
-      tzHours = Int32.Parse(num);
-      // Set tzMinutes to clear out default local tz offset
-      tzMinutes = 0;
-
-      if (offset == end)
-      {
-        return;
-      }
-
-      if (date[offset] != ':')
-      {
-        throw new GedcomxDateException("Invalid Date: Invalid tzHour-tzMinute Separator");
-      }
-
-      if (end - offset < 3)
-      {
-        throw new GedcomxDateException("Invalid Date: tzSecond must be 2 digits");
-      }
-
-      offset++;
-      num = "";
-      for (int i = 0; i < 2; i++)
-      {
-        if (!Char.IsDigit(date[offset]))
-        {
-          throw new GedcomxDateException("Invalid Date: Malformed tzMinutes");
-        }
-        num += date[offset++];
-      }
-
-      tzMinutes = Int32.Parse(num);
-
-      if (offset == end)
-      {
-        return;
-      }
-      else
-      {
-        throw new GedcomxDateException("Invalid Date: Malformed Timezone - No characters allowed after tzSeconds");
-      }
-
-    }
-
-    /// <summary>
-    /// Gets the type of GEDCOM X date. This property always returns SIMPLE for this instance.
-    /// </summary>
-    /// <value>
-    /// The type of GEDCOM X date.
-    /// </value>
-    public override GedcomxDateType Type
-    {
-      get
-      {
-        return GedcomxDateType.SIMPLE;
-      }
-    }
-
-    /// <summary>
-    /// Determines whether this date is approximate. This method always returns <c>false</c> for this instance.
-    /// </summary>
-    /// <value>
-    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-    /// </value>
-    public override bool IsApproximate
-    {
-      get
-      {
-        return false;
-      }
-    }
-
-    /// <summary>
-    /// The formal representation of this date.
-    /// </summary>
-    /// <value>
-    /// The formal representation of this date.
-    /// </value>
-    public override String FormalString
-    {
-      get
-      {
-        StringBuilder simple = new StringBuilder();
-
-        simple.Append(year >= 0 ? "+" : "-").Append(String.Format("{0:0000}", Math.Abs(year.Value)));
-
-        if (month != null)
-        {
-          simple.Append("-").Append(String.Format("{0:00}", month));
+            ParseDate(date);
         }
 
-        if (day != null)
+        /// <summary>
+        /// Parses the date of the specified formal date string and loads the results into the current instance.
+        /// </summary>
+        /// <param name="date">The formal date string to parse.</param>
+        /// <exception cref="Gedcomx.Date.GedcomxDateException">
+        /// Thrown if the formal date string does not meet the expected format.
+        /// </exception>
+        private void ParseDate(String date)
         {
-          simple.Append("-").Append(String.Format("{0:00}", day));
+            // There is a minimum length of 5 characters
+            if (date.Length < 5)
+            {
+                throw new GedcomxDateException("Invalid Date: Must have at least [+-]YYYY");
+            }
+
+            int end = date.Length;
+            int offset = 0;
+            String num;
+
+            // Must start with a + or -
+            if (date[offset] != '+' && date[offset] != '-')
+            {
+                throw new GedcomxDateException("Invalid Date: Must begin with + or -");
+            }
+
+            offset++;
+            num = date[0] == '-' ? "-" : "";
+            for (int i = 0; i < 4; i++)
+            {
+                if (!Char.IsDigit(date[offset]))
+                {
+                    throw new GedcomxDateException("Invalid Date: Malformed Year");
+                }
+                num += date[offset++];
+            }
+
+            year = Int32.Parse(num);
+
+            if (offset == end)
+            {
+                return;
+            }
+
+            // If there is time
+            if (date[offset] == 'T')
+            {
+                ParseTime(date.Substring(offset + 1));
+                return;
+            }
+
+            // Month
+            if (date[offset] != '-')
+            {
+                throw new GedcomxDateException("Invalid Date: Invalid Year-Month Separator");
+            }
+
+            if (end - offset < 3)
+            {
+                throw new GedcomxDateException("Invalid Date: Month must be 2 digits");
+            }
+
+            offset++;
+            num = "";
+            for (int i = 0; i < 2; i++)
+            {
+                if (!Char.IsDigit(date[offset]))
+                {
+                    throw new GedcomxDateException("Invalid Date: Malformed Month");
+                }
+                num += date[offset++];
+            }
+
+            month = Int32.Parse(num);
+
+            if (month < 1 || month > 12)
+            {
+                throw new GedcomxDateException("Invalid Date: Month must be between 1 and 12");
+            }
+
+            if (offset == end)
+            {
+                return;
+            }
+
+            // If there is time
+            if (date[offset] == 'T')
+            {
+                ParseTime(date.Substring(offset + 1));
+                return;
+            }
+
+            // Day
+            if (date[offset] != '-')
+            {
+                throw new GedcomxDateException("Invalid Date: Invalid Month-Day Separator");
+            }
+
+            if (end - offset < 3)
+            {
+                throw new GedcomxDateException("Invalid Date: Day must be 2 digits");
+            }
+
+            offset++;
+            num = "";
+            for (int i = 0; i < 2; i++)
+            {
+                if (!Char.IsDigit(date[offset]))
+                {
+                    throw new GedcomxDateException("Invalid Date: Malformed Day");
+                }
+                num += date[offset++];
+            }
+
+            day = Int32.Parse(num);
+
+            if (day < 1)
+            {
+                throw new GedcomxDateException("Invalid Date: Day 0 does not exist");
+            }
+
+            int daysInMonth = DateTime.DaysInMonth(year.Value, month.Value);
+            if (day > daysInMonth)
+            {
+                throw new GedcomxDateException("Invalid Date: There are only " + daysInMonth + " days in Month " + month + " year " + year);
+            }
+
+            if (offset == end)
+            {
+                return;
+            }
+
+            if (date[offset] == 'T')
+            {
+                ParseTime(date.Substring(offset + 1));
+            }
+            else
+            {
+                throw new GedcomxDateException("Invalid Date: +YYYY-MM-DD must have T before time");
+            }
+
         }
 
-        if (hours != null)
+        /// <summary>
+        /// Parses the time portion of the formal string
+        /// </summary>
+        /// <param name="date">The formal date string, excluding the date.</param>
+        /// <exception cref="Gedcomx.Date.GedcomxDateException">
+        /// Thrown if the formal date string does not meet the expected format. The specific reason will be given at runtime.
+        /// </exception>
+        private void ParseTime(String date)
         {
-          simple.Append("T").Append(String.Format("{0:00}", hours));
+            int offset = 0;
+            int end = date.Length;
+            String num;
+            bool flag24 = false;
 
-          if (minutes != null)
-          {
-            simple.Append(":").Append(String.Format("{0:00}", minutes));
-          }
+            // Always initialize the Timezone to the local offset.
+            // It may be overridden if set
+            TimeZone tz = TimeZone.CurrentTimeZone;
+            double offsetInMillis = tz.GetUtcOffset(DateTime.Now).TotalMilliseconds;
+            tzHours = Convert.ToInt32(offsetInMillis / 3600000);
+            tzMinutes = Convert.ToInt32((offsetInMillis / 60000) % 60);
 
-          if (seconds != null)
-          {
-            simple.Append(":").Append(String.Format("{0:00}", seconds));
-          }
+            // You must at least have hours
+            if (end < 2)
+            {
+                throw new GedcomxDateException("Invalid Date: Hours must be 2 digits");
+            }
 
-          // If we have time we always have tz
-          if (tzHours == 0 && tzMinutes == 0)
-          {
-            simple.Append("Z");
-          }
-          else
-          {
-            simple.Append(tzHours >= 0 ? "+" : "-").Append(String.Format("{0:00}", Math.Abs(tzHours.Value)));
-            simple.Append(":").Append(String.Format("{0:00}", tzMinutes));
-          }
+            num = "";
+            for (int i = 0; i < 2; i++)
+            {
+                if (!Char.IsDigit(date[offset]))
+                {
+                    throw new GedcomxDateException("Invalid Date: Malformed Hours");
+                }
+                num += date[offset++];
+            }
+
+            hours = Int32.Parse(num);
+
+            if (hours > 24)
+            {
+                throw new GedcomxDateException("Invalid Date: Hours must be between 0 and 24");
+            }
+
+            if (hours == 24)
+            {
+                flag24 = true;
+            }
+
+            if (offset == end)
+            {
+                return;
+            }
+
+            // If there is a timezone offset
+            if (date[offset] == '+' || date[offset] == '-' || date[offset] == 'Z')
+            {
+                ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
+                return;
+            }
+
+            if (date[offset] != ':')
+            {
+                throw new GedcomxDateException("Invalid Date: Invalid Hour-Minute Separator");
+            }
+
+            if (end - offset < 3)
+            {
+                throw new GedcomxDateException("Invalid Date: Minutes must be 2 digits");
+            }
+
+            offset++;
+            num = "";
+            for (int i = 0; i < 2; i++)
+            {
+                if (!Char.IsDigit(date[offset]))
+                {
+                    throw new GedcomxDateException("Invalid Date: Malformed Minutes");
+                }
+                num += date[offset++];
+            }
+
+            minutes = Int32.Parse(num);
+
+            if (minutes > 59)
+            {
+                throw new GedcomxDateException("Invalid Date: Minutes must be between 0 and 59");
+            }
+
+            if (flag24 && minutes != 0)
+            {
+                throw new GedcomxDateException("Invalid Date: Hours of 24 requires 00 Minutes");
+            }
+
+            if (offset == end)
+            {
+                return;
+            }
+
+            // If there is a timezone offset
+            if (date[offset] == '+' || date[offset] == '-' || date[offset] == 'Z')
+            {
+                ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
+                return;
+            }
+
+            if (date[offset] != ':')
+            {
+                throw new GedcomxDateException("Invalid Date: Invalid Minute-Second Separator");
+            }
+
+            if (end - offset < 3)
+            {
+                throw new GedcomxDateException("Invalid Date: Seconds must be 2 digits");
+            }
+
+            offset++;
+            num = "";
+            for (int i = 0; i < 2; i++)
+            {
+                if (!Char.IsDigit(date[offset]))
+                {
+                    throw new GedcomxDateException("Invalid Date: Malformed Seconds");
+                }
+                num += date[offset++];
+            }
+
+            seconds = Int32.Parse(num);
+
+            if (seconds > 59)
+            {
+                throw new GedcomxDateException("Invalid Date: Seconds must be between 0 and 59");
+            }
+
+            if (flag24 && seconds != 0)
+            {
+                throw new GedcomxDateException("Invalid Date: Hours of 24 requires 00 Seconds");
+            }
+
+            if (offset == end)
+            {
+                return;
+            }
+            else
+            {
+                ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
+            }
+
         }
 
-        return simple.ToString();
-      }
-    }
+        /**
+         * Parse the timezone portion of the formal string
+         * @param date The date string (minus the date and time)
+         */
+        /// <summary>
+        /// Parses the timezone portion of the formal date string.
+        /// </summary>
+        /// <param name="date">The formal date string to parse (excluding the date and time).</param>
+        /// <exception cref="Gedcomx.Date.GedcomxDateException">
+        /// Thrown if the formal date string does not meet the expected format. The specific reason will be given at runtime.
+        /// </exception>
+        private void ParseTimezone(String date)
+        {
+            int offset = 0;
+            int end = date.Length;
+            String num;
 
-    /// <summary>
-    /// Gets the year of the current date if available.
-    /// </summary>
-    /// <value>
-    /// The year of the current date if available.
-    /// </value>
-    public Int32? Year
-    {
-      get
-      {
-        return year;
-      }
-    }
+            // If Z we're done
+            if (date[offset] == 'Z')
+            {
+                if (end == 1)
+                {
+                    tzHours = 0;
+                    tzMinutes = 0;
+                    return;
+                }
+                else
+                {
+                    throw new GedcomxDateException("Invalid Date: Malformed Timezone - No Characters allowed after Z");
+                }
+            }
 
-    /// <summary>
-    /// Gets the month of the current date if available.
-    /// </summary>
-    /// <value>
-    /// The month of the current date if available.
-    /// </value>
-    public Int32? Month
-    {
-      get
-      {
-        return month;
-      }
-    }
+            if (end - offset < 3)
+            {
+                throw new GedcomxDateException("Invalid Date: Malformed Timezone - tzHours must be [+-] followed by 2 digits");
+            }
 
-    /// <summary>
-    /// Gets the day of the current date if available.
-    /// </summary>
-    /// <value>
-    /// The day of the current date if available.
-    /// </value>
-    public Int32? Day
-    {
-      get
-      {
-        return day;
-      }
-    }
+            // Must start with a + or -
+            if (date[offset] != '+' && date[offset] != '-')
+            {
+                throw new GedcomxDateException("Invalid Date: TimeZone Hours must begin with + or -");
+            }
 
-    /// <summary>
-    /// Gets the hours of the current date if available.
-    /// </summary>
-    /// <value>
-    /// The hours of the current date if available.
-    /// </value>
-    public Int32? Hours
-    {
-      get
-      {
-        return hours;
-      }
-    }
+            offset++;
+            num = date[0] == '-' ? "-" : "";
+            for (int i = 0; i < 2; i++)
+            {
+                if (!Char.IsDigit(date[offset]))
+                {
+                    throw new GedcomxDateException("Invalid Date: Malformed tzHours");
+                }
+                num += date[offset++];
+            }
 
-    /// <summary>
-    /// Gets the minutes of the current date if available.
-    /// </summary>
-    /// <value>
-    /// The minutes of the current date if available.
-    /// </value>
-    public Int32? Minutes
-    {
-      get
-      {
-        return minutes;
-      }
-    }
+            tzHours = Int32.Parse(num);
+            // Set tzMinutes to clear out default local tz offset
+            tzMinutes = 0;
 
-    /// <summary>
-    /// Gets the seconds of the current date if available.
-    /// </summary>
-    /// <value>
-    /// The seconds of the current date if available.
-    /// </value>
-    public Int32? Seconds
-    {
-      get
-      {
-        return seconds;
-      }
-    }
+            if (offset == end)
+            {
+                return;
+            }
 
-    /// <summary>
-    /// Gets the timezone hours of the current date if available.
-    /// </summary>
-    /// <value>
-    /// The timezone hours of the current date if available.
-    /// </value>
-    public Int32? TzHours
-    {
-      get
-      {
-        return tzHours;
-      }
-    }
+            if (date[offset] != ':')
+            {
+                throw new GedcomxDateException("Invalid Date: Invalid tzHour-tzMinute Separator");
+            }
 
-    /// <summary>
-    /// Gets the timezone minutes of the current date if available.
-    /// </summary>
-    /// <value>
-    /// The timezone minutes of the current date if available.
-    /// </value>
-    public Int32? TzMinutes
-    {
-      get
-      {
-        return tzMinutes;
-      }
+            if (end - offset < 3)
+            {
+                throw new GedcomxDateException("Invalid Date: tzSecond must be 2 digits");
+            }
+
+            offset++;
+            num = "";
+            for (int i = 0; i < 2; i++)
+            {
+                if (!Char.IsDigit(date[offset]))
+                {
+                    throw new GedcomxDateException("Invalid Date: Malformed tzMinutes");
+                }
+                num += date[offset++];
+            }
+
+            tzMinutes = Int32.Parse(num);
+
+            if (offset == end)
+            {
+                return;
+            }
+            else
+            {
+                throw new GedcomxDateException("Invalid Date: Malformed Timezone - No characters allowed after tzSeconds");
+            }
+
+        }
+
+        /// <summary>
+        /// Gets the type of GEDCOM X date. This property always returns SIMPLE for this instance.
+        /// </summary>
+        /// <value>
+        /// The type of GEDCOM X date.
+        /// </value>
+        public override GedcomxDateType Type
+        {
+            get
+            {
+                return GedcomxDateType.SIMPLE;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether this date is approximate. This method always returns <c>false</c> for this instance.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+        /// </value>
+        public override bool IsApproximate
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// The formal representation of this date.
+        /// </summary>
+        /// <value>
+        /// The formal representation of this date.
+        /// </value>
+        public override String FormalString
+        {
+            get
+            {
+                StringBuilder simple = new StringBuilder();
+
+                simple.Append(year >= 0 ? "+" : "-").Append(String.Format("{0:0000}", Math.Abs(year.Value)));
+
+                if (month != null)
+                {
+                    simple.Append("-").Append(String.Format("{0:00}", month));
+                }
+
+                if (day != null)
+                {
+                    simple.Append("-").Append(String.Format("{0:00}", day));
+                }
+
+                if (hours != null)
+                {
+                    simple.Append("T").Append(String.Format("{0:00}", hours));
+
+                    if (minutes != null)
+                    {
+                        simple.Append(":").Append(String.Format("{0:00}", minutes));
+                    }
+
+                    if (seconds != null)
+                    {
+                        simple.Append(":").Append(String.Format("{0:00}", seconds));
+                    }
+
+                    // If we have time we always have tz
+                    if (tzHours == 0 && tzMinutes == 0)
+                    {
+                        simple.Append("Z");
+                    }
+                    else
+                    {
+                        simple.Append(tzHours >= 0 ? "+" : "-").Append(String.Format("{0:00}", Math.Abs(tzHours.Value)));
+                        simple.Append(":").Append(String.Format("{0:00}", tzMinutes));
+                    }
+                }
+
+                return simple.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Gets the year of the current date if available.
+        /// </summary>
+        /// <value>
+        /// The year of the current date if available.
+        /// </value>
+        public Int32? Year
+        {
+            get
+            {
+                return year;
+            }
+        }
+
+        /// <summary>
+        /// Gets the month of the current date if available.
+        /// </summary>
+        /// <value>
+        /// The month of the current date if available.
+        /// </value>
+        public Int32? Month
+        {
+            get
+            {
+                return month;
+            }
+        }
+
+        /// <summary>
+        /// Gets the day of the current date if available.
+        /// </summary>
+        /// <value>
+        /// The day of the current date if available.
+        /// </value>
+        public Int32? Day
+        {
+            get
+            {
+                return day;
+            }
+        }
+
+        /// <summary>
+        /// Gets the hours of the current date if available.
+        /// </summary>
+        /// <value>
+        /// The hours of the current date if available.
+        /// </value>
+        public Int32? Hours
+        {
+            get
+            {
+                return hours;
+            }
+        }
+
+        /// <summary>
+        /// Gets the minutes of the current date if available.
+        /// </summary>
+        /// <value>
+        /// The minutes of the current date if available.
+        /// </value>
+        public Int32? Minutes
+        {
+            get
+            {
+                return minutes;
+            }
+        }
+
+        /// <summary>
+        /// Gets the seconds of the current date if available.
+        /// </summary>
+        /// <value>
+        /// The seconds of the current date if available.
+        /// </value>
+        public Int32? Seconds
+        {
+            get
+            {
+                return seconds;
+            }
+        }
+
+        /// <summary>
+        /// Gets the timezone hours of the current date if available.
+        /// </summary>
+        /// <value>
+        /// The timezone hours of the current date if available.
+        /// </value>
+        public Int32? TzHours
+        {
+            get
+            {
+                return tzHours;
+            }
+        }
+
+        /// <summary>
+        /// Gets the timezone minutes of the current date if available.
+        /// </summary>
+        /// <value>
+        /// The timezone minutes of the current date if available.
+        /// </value>
+        public Int32? TzMinutes
+        {
+            get
+            {
+                return tzMinutes;
+            }
+        }
     }
-  }
 }

--- a/GEDCOM X Date/GedcomxDateSimple.cs
+++ b/GEDCOM X Date/GedcomxDateSimple.cs
@@ -7,610 +7,610 @@ using System.Threading.Tasks;
 
 namespace Gedcomx.Date
 {
-  /// <summary>
-  /// Represents a simple GEDCOM X date.
-  /// </summary>
-  public class GedcomxDateSimple : GedcomxDate
-  {
-    private Int32? year = null;
-    private Int32? month = null;
-    private Int32? day = null;
-    private Int32? hours = null;
-    private Int32? minutes = null;
-    private Int32? seconds = null;
-    private Int32? tzHours = null;
-    private Int32? tzMinutes = null;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="GedcomxDateSimple"/> class.
-    /// </summary>
-    /// <param name="date">The formal date string that describes a simple GEDCOM X date.</param>
-    public GedcomxDateSimple(String date)
-    {
-      ParseDate(date);
-    }
-
-    /// <summary>
-    /// Parses the date of the specified formal date string and loads the results into the current instance.
-    /// </summary>
-    /// <param name="date">The formal date string to parse.</param>
-    /// <exception cref="Gedcomx.Date.GedcomxDateException">
-    /// Thrown if the formal date string does not meet the expected format.
-    /// </exception>
-    private void ParseDate(String date)
-    {
-      // There is a minimum length of 5 characters
-      if (date.Length < 5)
-      {
-        throw new GedcomxDateException("Invalid Date: Must have at least [+-]YYYY");
-      }
-
-      int end = date.Length;
-      int offset = 0;
-      String num;
-
-      // Must start with a + or -
-      if (date[offset] != '+' && date[offset] != '-')
-      {
-        throw new GedcomxDateException("Invalid Date: Must begin with + or -");
-      }
-
-      offset++;
-      num = date[0] == '-' ? "-" : "";
-      for (int i = 0; i < 4; i++)
-      {
-        if (!Char.IsDigit(date[offset]))
-        {
-          throw new GedcomxDateException("Invalid Date: Malformed Year");
-        }
-        num += date[offset++];
-      }
-
-      year = Int32.Parse(num);
-
-      if (offset == end)
-      {
-        return;
-      }
-
-      // If there is time
-      if (date[offset] == 'T')
-      {
-        ParseTime(date.Substring(offset + 1));
-        return;
-      }
-
-      // Month
-      if (date[offset] != '-')
-      {
-        throw new GedcomxDateException("Invalid Date: Invalid Year-Month Separator");
-      }
-
-      if (end - offset < 3)
-      {
-        throw new GedcomxDateException("Invalid Date: Month must be 2 digits");
-      }
-
-      offset++;
-      num = "";
-      for (int i = 0; i < 2; i++)
-      {
-        if (!Char.IsDigit(date[offset]))
-        {
-          throw new GedcomxDateException("Invalid Date: Malformed Month");
-        }
-        num += date[offset++];
-      }
-
-      month = Int32.Parse(num);
-
-      if (month < 1 || month > 12)
-      {
-        throw new GedcomxDateException("Invalid Date: Month must be between 1 and 12");
-      }
-
-      if (offset == end)
-      {
-        return;
-      }
-
-      // If there is time
-      if (date[offset] == 'T')
-      {
-        ParseTime(date.Substring(offset + 1));
-        return;
-      }
-
-      // Day
-      if (date[offset] != '-')
-      {
-        throw new GedcomxDateException("Invalid Date: Invalid Month-Day Separator");
-      }
-
-      if (end - offset < 3)
-      {
-        throw new GedcomxDateException("Invalid Date: Day must be 2 digits");
-      }
-
-      offset++;
-      num = "";
-      for (int i = 0; i < 2; i++)
-      {
-        if (!Char.IsDigit(date[offset]))
-        {
-          throw new GedcomxDateException("Invalid Date: Malformed Day");
-        }
-        num += date[offset++];
-      }
-
-      day = Int32.Parse(num);
-
-      if (day < 1)
-      {
-        throw new GedcomxDateException("Invalid Date: Day 0 does not exist");
-      }
-
-      int daysInMonth = DateTime.DaysInMonth(year.Value, month.Value);
-      if (day > daysInMonth)
-      {
-        throw new GedcomxDateException("Invalid Date: There are only " + daysInMonth + " days in Month " + month + " year " + year);
-      }
-
-      if (offset == end)
-      {
-        return;
-      }
-
-      if (date[offset] == 'T')
-      {
-        ParseTime(date.Substring(offset + 1));
-      }
-      else
-      {
-        throw new GedcomxDateException("Invalid Date: +YYYY-MM-DD must have T before time");
-      }
-
-    }
-
-    /// <summary>
-    /// Parses the time portion of the formal string
-    /// </summary>
-    /// <param name="date">The formal date string, excluding the date.</param>
-    /// <exception cref="Gedcomx.Date.GedcomxDateException">
-    /// Thrown if the formal date string does not meet the expected format. The specific reason will be given at runtime.
-    /// </exception>
-    private void ParseTime(String date)
-    {
-      int offset = 0;
-      int end = date.Length;
-      String num;
-      bool flag24 = false;
-
-      // Always initialize the Timezone to the local offset.
-      // It may be overridden if set
-      TimeZone tz = TimeZone.CurrentTimeZone;
-      double offsetInMillis = tz.GetUtcOffset(DateTime.Now).TotalMilliseconds;
-      tzHours = Convert.ToInt32(offsetInMillis / 3600000);
-      tzMinutes = Convert.ToInt32((offsetInMillis / 60000) % 60);
-
-      // You must at least have hours
-      if (end < 2)
-      {
-        throw new GedcomxDateException("Invalid Date: Hours must be 2 digits");
-      }
-
-      num = "";
-      for (int i = 0; i < 2; i++)
-      {
-        if (!Char.IsDigit(date[offset]))
-        {
-          throw new GedcomxDateException("Invalid Date: Malformed Hours");
-        }
-        num += date[offset++];
-      }
-
-      hours = Int32.Parse(num);
-
-      if (hours > 24)
-      {
-        throw new GedcomxDateException("Invalid Date: Hours must be between 0 and 24");
-      }
-
-      if (hours == 24)
-      {
-        flag24 = true;
-      }
-
-      if (offset == end)
-      {
-        return;
-      }
-
-      // If there is a timezone offset
-      if (date[offset] == '+' || date[offset] == '-' || date[offset] == 'Z')
-      {
-        ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
-        return;
-      }
-
-      if (date[offset] != ':')
-      {
-        throw new GedcomxDateException("Invalid Date: Invalid Hour-Minute Separator");
-      }
-
-      if (end - offset < 3)
-      {
-        throw new GedcomxDateException("Invalid Date: Minutes must be 2 digits");
-      }
-
-      offset++;
-      num = "";
-      for (int i = 0; i < 2; i++)
-      {
-        if (!Char.IsDigit(date[offset]))
-        {
-          throw new GedcomxDateException("Invalid Date: Malformed Minutes");
-        }
-        num += date[offset++];
-      }
-
-      minutes = Int32.Parse(num);
-
-      if (minutes > 59)
-      {
-        throw new GedcomxDateException("Invalid Date: Minutes must be between 0 and 59");
-      }
-
-      if (flag24 && minutes != 0)
-      {
-        throw new GedcomxDateException("Invalid Date: Hours of 24 requires 00 Minutes");
-      }
-
-      if (offset == end)
-      {
-        return;
-      }
-
-      // If there is a timezone offset
-      if (date[offset] == '+' || date[offset] == '-' || date[offset] == 'Z')
-      {
-        ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
-        return;
-      }
-
-      if (date[offset] != ':')
-      {
-        throw new GedcomxDateException("Invalid Date: Invalid Minute-Second Separator");
-      }
-
-      if (end - offset < 3)
-      {
-        throw new GedcomxDateException("Invalid Date: Seconds must be 2 digits");
-      }
-
-      offset++;
-      num = "";
-      for (int i = 0; i < 2; i++)
-      {
-        if (!Char.IsDigit(date[offset]))
-        {
-          throw new GedcomxDateException("Invalid Date: Malformed Seconds");
-        }
-        num += date[offset++];
-      }
-
-      seconds = Int32.Parse(num);
-
-      if (seconds > 59)
-      {
-        throw new GedcomxDateException("Invalid Date: Seconds must be between 0 and 59");
-      }
-
-      if (flag24 && seconds != 0)
-      {
-        throw new GedcomxDateException("Invalid Date: Hours of 24 requires 00 Seconds");
-      }
-
-      if (offset == end)
-      {
-        return;
-      }
-      else
-      {
-        ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
-      }
-
-    }
-
-    /**
-     * Parse the timezone portion of the formal string
-     * @param date The date string (minus the date and time)
-     */
-    /// <summary>
-    /// Parses the timezone portion of the formal date string.
-    /// </summary>
-    /// <param name="date">The formal date string to parse (excluding the date and time).</param>
-    /// <exception cref="Gedcomx.Date.GedcomxDateException">
-    /// Thrown if the formal date string does not meet the expected format. The specific reason will be given at runtime.
-    /// </exception>
-    private void ParseTimezone(String date)
-    {
-      int offset = 0;
-      int end = date.Length;
-      String num;
-
-      // If Z we're done
-      if (date[offset] == 'Z')
-      {
-        if (end == 1)
-        {
-          tzHours = 0;
-          tzMinutes = 0;
-          return;
-        }
-        else
-        {
-          throw new GedcomxDateException("Invalid Date: Malformed Timezone - No Characters allowed after Z");
-        }
-      }
-
-      if (end - offset < 3)
-      {
-        throw new GedcomxDateException("Invalid Date: Malformed Timezone - tzHours must be [+-] followed by 2 digits");
-      }
-
-      // Must start with a + or -
-      if (date[offset] != '+' && date[offset] != '-')
-      {
-        throw new GedcomxDateException("Invalid Date: TimeZone Hours must begin with + or -");
-      }
-
-      offset++;
-      num = date[0] == '-' ? "-" : "";
-      for (int i = 0; i < 2; i++)
-      {
-        if (!Char.IsDigit(date[offset]))
-        {
-          throw new GedcomxDateException("Invalid Date: Malformed tzHours");
-        }
-        num += date[offset++];
-      }
-
-      tzHours = Int32.Parse(num);
-      // Set tzMinutes to clear out default local tz offset
-      tzMinutes = 0;
-
-      if (offset == end)
-      {
-        return;
-      }
-
-      if (date[offset] != ':')
-      {
-        throw new GedcomxDateException("Invalid Date: Invalid tzHour-tzMinute Separator");
-      }
-
-      if (end - offset < 3)
-      {
-        throw new GedcomxDateException("Invalid Date: tzSecond must be 2 digits");
-      }
-
-      offset++;
-      num = "";
-      for (int i = 0; i < 2; i++)
-      {
-        if (!Char.IsDigit(date[offset]))
-        {
-          throw new GedcomxDateException("Invalid Date: Malformed tzMinutes");
-        }
-        num += date[offset++];
-      }
-
-      tzMinutes = Int32.Parse(num);
-
-      if (offset == end)
-      {
-        return;
-      }
-      else
-      {
-        throw new GedcomxDateException("Invalid Date: Malformed Timezone - No characters allowed after tzSeconds");
-      }
-
-    }
-
-    /// <summary>
-    /// Gets the type of GEDCOM X date. This property always returns SIMPLE for this instance.
-    /// </summary>
-    /// <value>
-    /// The type of GEDCOM X date.
-    /// </value>
-    public override GedcomxDateType Type
-    {
-      get
-      {
-        return GedcomxDateType.SIMPLE;
-      }
-    }
-
-    /// <summary>
-    /// Determines whether this date is approximate. This method always returns <c>false</c> for this instance.
-    /// </summary>
-    /// <value>
-    ///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
-    /// </value>
-    public override bool IsApproximate
-    {
-      get
-      {
-        return false;
-      }
-    }
-
-    /// <summary>
-    /// The formal representation of this date.
-    /// </summary>
-    /// <value>
-    /// The formal representation of this date.
-    /// </value>
-    public override String FormalString
-    {
-      get
-      {
-        StringBuilder simple = new StringBuilder();
-
-        simple.Append(year >= 0 ? "+" : "-").Append(String.Format("{0:0000}", Math.Abs(year.Value)));
-
-        if (month != null)
-        {
-          simple.Append("-").Append(String.Format("{0:00}", month));
-        }
-
-        if (day != null)
-        {
-          simple.Append("-").Append(String.Format("{0:00}", day));
-        }
-
-        if (hours != null)
-        {
-          simple.Append("T").Append(String.Format("{0:00}", hours));
-
-          if (minutes != null)
-          {
-            simple.Append(":").Append(String.Format("{0:00}", minutes));
-          }
-
-          if (seconds != null)
-          {
-            simple.Append(":").Append(String.Format("{0:00}", seconds));
-          }
-
-          // If we have time we always have tz
-          if (tzHours == 0 && tzMinutes == 0)
-          {
-            simple.Append("Z");
-          }
-          else
-          {
-            simple.Append(tzHours >= 0 ? "+" : "-").Append(String.Format("{0:00}", Math.Abs(tzHours.Value)));
-            simple.Append(":").Append(String.Format("{0:00}", tzMinutes));
-          }
-        }
-
-        return simple.ToString();
-      }
-    }
-
-    /// <summary>
-    /// Gets the year of the current date if available.
-    /// </summary>
-    /// <value>
-    /// The year of the current date if available.
-    /// </value>
-    public Int32? Year
-    {
-      get
-      {
-        return year;
-      }
-    }
-
-    /// <summary>
-    /// Gets the month of the current date if available.
-    /// </summary>
-    /// <value>
-    /// The month of the current date if available.
-    /// </value>
-    public Int32? Month
-    {
-      get
-      {
-        return month;
-      }
-    }
-
-    /// <summary>
-    /// Gets the day of the current date if available.
-    /// </summary>
-    /// <value>
-    /// The day of the current date if available.
-    /// </value>
-    public Int32? Day
-    {
-      get
-      {
-        return day;
-      }
-    }
-
-    /// <summary>
-    /// Gets the hours of the current date if available.
-    /// </summary>
-    /// <value>
-    /// The hours of the current date if available.
-    /// </value>
-    public Int32? Hours
-    {
-      get
-      {
-        return hours;
-      }
-    }
-
-    /// <summary>
-    /// Gets the minutes of the current date if available.
-    /// </summary>
-    /// <value>
-    /// The minutes of the current date if available.
-    /// </value>
-    public Int32? Minutes
-    {
-      get
-      {
-        return minutes;
-      }
-    }
-
-    /// <summary>
-    /// Gets the seconds of the current date if available.
-    /// </summary>
-    /// <value>
-    /// The seconds of the current date if available.
-    /// </value>
-    public Int32? Seconds
-    {
-      get
-      {
-        return seconds;
-      }
-    }
-
-    /// <summary>
-    /// Gets the timezone hours of the current date if available.
-    /// </summary>
-    /// <value>
-    /// The timezone hours of the current date if available.
-    /// </value>
-    public Int32? TzHours
-    {
-      get
-      {
-        return tzHours;
-      }
-    }
-
-    /// <summary>
-    /// Gets the timezone minutes of the current date if available.
-    /// </summary>
-    /// <value>
-    /// The timezone minutes of the current date if available.
-    /// </value>
-    public Int32? TzMinutes
-    {
-      get
-      {
-        return tzMinutes;
-      }
-    }
-  }
+	/// <summary>
+	/// Represents a simple GEDCOM X date.
+	/// </summary>
+	public class GedcomxDateSimple : GedcomxDate
+	{
+		private Int32? year = null;
+		private Int32? month = null;
+		private Int32? day = null;
+		private Int32? hours = null;
+		private Int32? minutes = null;
+		private Int32? seconds = null;
+		private Int32? tzHours = null;
+		private Int32? tzMinutes = null;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="GedcomxDateSimple"/> class.
+		/// </summary>
+		/// <param name="date">The formal date string that describes a simple GEDCOM X date.</param>
+		public GedcomxDateSimple(String date)
+		{
+			ParseDate(date);
+		}
+
+		/// <summary>
+		/// Parses the date of the specified formal date string and loads the results into the current instance.
+		/// </summary>
+		/// <param name="date">The formal date string to parse.</param>
+		/// <exception cref="Gedcomx.Date.GedcomxDateException">
+		/// Thrown if the formal date string does not meet the expected format.
+		/// </exception>
+		private void ParseDate(String date)
+		{
+			// There is a minimum length of 5 characters
+			if (date.Length < 5)
+			{
+				throw new GedcomxDateException("Invalid Date: Must have at least [+-]YYYY");
+			}
+
+			int end = date.Length;
+			int offset = 0;
+			String num;
+
+			// Must start with a + or -
+			if (date[offset] != '+' && date[offset] != '-')
+			{
+				throw new GedcomxDateException("Invalid Date: Must begin with + or -");
+			}
+
+			offset++;
+			num = date[0] == '-' ? "-" : "";
+			for (int i = 0; i < 4; i++)
+			{
+				if (!Char.IsDigit(date[offset]))
+				{
+					throw new GedcomxDateException("Invalid Date: Malformed Year");
+				}
+				num += date[offset++];
+			}
+
+			year = Int32.Parse(num);
+
+			if (offset == end)
+			{
+				return;
+			}
+
+			// If there is time
+			if (date[offset] == 'T')
+			{
+				ParseTime(date.Substring(offset + 1));
+				return;
+			}
+
+			// Month
+			if (date[offset] != '-')
+			{
+				throw new GedcomxDateException("Invalid Date: Invalid Year-Month Separator");
+			}
+
+			if (end - offset < 3)
+			{
+				throw new GedcomxDateException("Invalid Date: Month must be 2 digits");
+			}
+
+			offset++;
+			num = "";
+			for (int i = 0; i < 2; i++)
+			{
+				if (!Char.IsDigit(date[offset]))
+				{
+					throw new GedcomxDateException("Invalid Date: Malformed Month");
+				}
+				num += date[offset++];
+			}
+
+			month = Int32.Parse(num);
+
+			if (month < 1 || month > 12)
+			{
+				throw new GedcomxDateException("Invalid Date: Month must be between 1 and 12");
+			}
+
+			if (offset == end)
+			{
+				return;
+			}
+
+			// If there is time
+			if (date[offset] == 'T')
+			{
+				ParseTime(date.Substring(offset + 1));
+				return;
+			}
+
+			// Day
+			if (date[offset] != '-')
+			{
+				throw new GedcomxDateException("Invalid Date: Invalid Month-Day Separator");
+			}
+
+			if (end - offset < 3)
+			{
+				throw new GedcomxDateException("Invalid Date: Day must be 2 digits");
+			}
+
+			offset++;
+			num = "";
+			for (int i = 0; i < 2; i++)
+			{
+				if (!Char.IsDigit(date[offset]))
+				{
+					throw new GedcomxDateException("Invalid Date: Malformed Day");
+				}
+				num += date[offset++];
+			}
+
+			day = Int32.Parse(num);
+
+			if (day < 1)
+			{
+				throw new GedcomxDateException("Invalid Date: Day 0 does not exist");
+			}
+
+			int daysInMonth = DateTime.DaysInMonth(year.Value, month.Value);
+			if (day > daysInMonth)
+			{
+				throw new GedcomxDateException("Invalid Date: There are only " + daysInMonth + " days in Month " + month + " year " + year);
+			}
+
+			if (offset == end)
+			{
+				return;
+			}
+
+			if (date[offset] == 'T')
+			{
+				ParseTime(date.Substring(offset + 1));
+			}
+			else
+			{
+				throw new GedcomxDateException("Invalid Date: +YYYY-MM-DD must have T before time");
+			}
+
+		}
+
+		/// <summary>
+		/// Parses the time portion of the formal string
+		/// </summary>
+		/// <param name="date">The formal date string, excluding the date.</param>
+		/// <exception cref="Gedcomx.Date.GedcomxDateException">
+		/// Thrown if the formal date string does not meet the expected format. The specific reason will be given at runtime.
+		/// </exception>
+		private void ParseTime(String date)
+		{
+			int offset = 0;
+			int end = date.Length;
+			String num;
+			bool flag24 = false;
+
+			// Always initialize the Timezone to the local offset.
+			// It may be overridden if set
+			TimeZone tz = TimeZone.CurrentTimeZone;
+			double offsetInMillis = tz.GetUtcOffset(DateTime.Now).TotalMilliseconds;
+			tzHours = Convert.ToInt32(offsetInMillis / 3600000);
+			tzMinutes = Convert.ToInt32((offsetInMillis / 60000) % 60);
+
+			// You must at least have hours
+			if (end < 2)
+			{
+				throw new GedcomxDateException("Invalid Date: Hours must be 2 digits");
+			}
+
+			num = "";
+			for (int i = 0; i < 2; i++)
+			{
+				if (!Char.IsDigit(date[offset]))
+				{
+					throw new GedcomxDateException("Invalid Date: Malformed Hours");
+				}
+				num += date[offset++];
+			}
+
+			hours = Int32.Parse(num);
+
+			if (hours > 24)
+			{
+				throw new GedcomxDateException("Invalid Date: Hours must be between 0 and 24");
+			}
+
+			if (hours == 24)
+			{
+				flag24 = true;
+			}
+
+			if (offset == end)
+			{
+				return;
+			}
+
+			// If there is a timezone offset
+			if (date[offset] == '+' || date[offset] == '-' || date[offset] == 'Z')
+			{
+				ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
+				return;
+			}
+
+			if (date[offset] != ':')
+			{
+				throw new GedcomxDateException("Invalid Date: Invalid Hour-Minute Separator");
+			}
+
+			if (end - offset < 3)
+			{
+				throw new GedcomxDateException("Invalid Date: Minutes must be 2 digits");
+			}
+
+			offset++;
+			num = "";
+			for (int i = 0; i < 2; i++)
+			{
+				if (!Char.IsDigit(date[offset]))
+				{
+					throw new GedcomxDateException("Invalid Date: Malformed Minutes");
+				}
+				num += date[offset++];
+			}
+
+			minutes = Int32.Parse(num);
+
+			if (minutes > 59)
+			{
+				throw new GedcomxDateException("Invalid Date: Minutes must be between 0 and 59");
+			}
+
+			if (flag24 && minutes != 0)
+			{
+				throw new GedcomxDateException("Invalid Date: Hours of 24 requires 00 Minutes");
+			}
+
+			if (offset == end)
+			{
+				return;
+			}
+
+			// If there is a timezone offset
+			if (date[offset] == '+' || date[offset] == '-' || date[offset] == 'Z')
+			{
+				ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
+				return;
+			}
+
+			if (date[offset] != ':')
+			{
+				throw new GedcomxDateException("Invalid Date: Invalid Minute-Second Separator");
+			}
+
+			if (end - offset < 3)
+			{
+				throw new GedcomxDateException("Invalid Date: Seconds must be 2 digits");
+			}
+
+			offset++;
+			num = "";
+			for (int i = 0; i < 2; i++)
+			{
+				if (!Char.IsDigit(date[offset]))
+				{
+					throw new GedcomxDateException("Invalid Date: Malformed Seconds");
+				}
+				num += date[offset++];
+			}
+
+			seconds = Int32.Parse(num);
+
+			if (seconds > 59)
+			{
+				throw new GedcomxDateException("Invalid Date: Seconds must be between 0 and 59");
+			}
+
+			if (flag24 && seconds != 0)
+			{
+				throw new GedcomxDateException("Invalid Date: Hours of 24 requires 00 Seconds");
+			}
+
+			if (offset == end)
+			{
+				return;
+			}
+			else
+			{
+				ParseTimezone(date.Substring(offset)); // Don't remove the character when calling
+			}
+
+		}
+
+		/**
+		 * Parse the timezone portion of the formal string
+		 * @param date The date string (minus the date and time)
+		 */
+		/// <summary>
+		/// Parses the timezone portion of the formal date string.
+		/// </summary>
+		/// <param name="date">The formal date string to parse (excluding the date and time).</param>
+		/// <exception cref="Gedcomx.Date.GedcomxDateException">
+		/// Thrown if the formal date string does not meet the expected format. The specific reason will be given at runtime.
+		/// </exception>
+		private void ParseTimezone(String date)
+		{
+			int offset = 0;
+			int end = date.Length;
+			String num;
+
+			// If Z we're done
+			if (date[offset] == 'Z')
+			{
+				if (end == 1)
+				{
+					tzHours = 0;
+					tzMinutes = 0;
+					return;
+				}
+				else
+				{
+					throw new GedcomxDateException("Invalid Date: Malformed Timezone - No Characters allowed after Z");
+				}
+			}
+
+			if (end - offset < 3)
+			{
+				throw new GedcomxDateException("Invalid Date: Malformed Timezone - tzHours must be [+-] followed by 2 digits");
+			}
+
+			// Must start with a + or -
+			if (date[offset] != '+' && date[offset] != '-')
+			{
+				throw new GedcomxDateException("Invalid Date: TimeZone Hours must begin with + or -");
+			}
+
+			offset++;
+			num = date[0] == '-' ? "-" : "";
+			for (int i = 0; i < 2; i++)
+			{
+				if (!Char.IsDigit(date[offset]))
+				{
+					throw new GedcomxDateException("Invalid Date: Malformed tzHours");
+				}
+				num += date[offset++];
+			}
+
+			tzHours = Int32.Parse(num);
+			// Set tzMinutes to clear out default local tz offset
+			tzMinutes = 0;
+
+			if (offset == end)
+			{
+				return;
+			}
+
+			if (date[offset] != ':')
+			{
+				throw new GedcomxDateException("Invalid Date: Invalid tzHour-tzMinute Separator");
+			}
+
+			if (end - offset < 3)
+			{
+				throw new GedcomxDateException("Invalid Date: tzSecond must be 2 digits");
+			}
+
+			offset++;
+			num = "";
+			for (int i = 0; i < 2; i++)
+			{
+				if (!Char.IsDigit(date[offset]))
+				{
+					throw new GedcomxDateException("Invalid Date: Malformed tzMinutes");
+				}
+				num += date[offset++];
+			}
+
+			tzMinutes = Int32.Parse(num);
+
+			if (offset == end)
+			{
+				return;
+			}
+			else
+			{
+				throw new GedcomxDateException("Invalid Date: Malformed Timezone - No characters allowed after tzSeconds");
+			}
+
+		}
+
+		/// <summary>
+		/// Gets the type of GEDCOM X date. This property always returns SIMPLE for this instance.
+		/// </summary>
+		/// <value>
+		/// The type of GEDCOM X date.
+		/// </value>
+		public override GedcomxDateType Type
+		{
+			get
+			{
+				return GedcomxDateType.SIMPLE;
+			}
+		}
+
+		/// <summary>
+		/// Determines whether this date is approximate. This method always returns <c>false</c> for this instance.
+		/// </summary>
+		/// <value>
+		///   <c>true</c> if this date is approximate; otherwise, <c>false</c>.
+		/// </value>
+		public override bool IsApproximate
+		{
+			get
+			{
+				return false;
+			}
+		}
+
+		/// <summary>
+		/// The formal representation of this date.
+		/// </summary>
+		/// <value>
+		/// The formal representation of this date.
+		/// </value>
+		public override String FormalString
+		{
+			get
+			{
+				StringBuilder simple = new StringBuilder();
+
+				simple.Append(year >= 0 ? "+" : "-").Append(String.Format("{0:0000}", Math.Abs(year.Value)));
+
+				if (month != null)
+				{
+					simple.Append("-").Append(String.Format("{0:00}", month));
+				}
+
+				if (day != null)
+				{
+					simple.Append("-").Append(String.Format("{0:00}", day));
+				}
+
+				if (hours != null)
+				{
+					simple.Append("T").Append(String.Format("{0:00}", hours));
+
+					if (minutes != null)
+					{
+						simple.Append(":").Append(String.Format("{0:00}", minutes));
+					}
+
+					if (seconds != null)
+					{
+						simple.Append(":").Append(String.Format("{0:00}", seconds));
+					}
+
+					// If we have time we always have tz
+					if (tzHours == 0 && tzMinutes == 0)
+					{
+						simple.Append("Z");
+					}
+					else
+					{
+						simple.Append(tzHours >= 0 ? "+" : "-").Append(String.Format("{0:00}", Math.Abs(tzHours.Value)));
+						simple.Append(":").Append(String.Format("{0:00}", tzMinutes));
+					}
+				}
+
+				return simple.ToString();
+			}
+		}
+
+		/// <summary>
+		/// Gets the year of the current date if available.
+		/// </summary>
+		/// <value>
+		/// The year of the current date if available.
+		/// </value>
+		public Int32? Year
+		{
+			get
+			{
+				return year;
+			}
+		}
+
+		/// <summary>
+		/// Gets the month of the current date if available.
+		/// </summary>
+		/// <value>
+		/// The month of the current date if available.
+		/// </value>
+		public Int32? Month
+		{
+			get
+			{
+				return month;
+			}
+		}
+
+		/// <summary>
+		/// Gets the day of the current date if available.
+		/// </summary>
+		/// <value>
+		/// The day of the current date if available.
+		/// </value>
+		public Int32? Day
+		{
+			get
+			{
+				return day;
+			}
+		}
+
+		/// <summary>
+		/// Gets the hours of the current date if available.
+		/// </summary>
+		/// <value>
+		/// The hours of the current date if available.
+		/// </value>
+		public Int32? Hours
+		{
+			get
+			{
+				return hours;
+			}
+		}
+
+		/// <summary>
+		/// Gets the minutes of the current date if available.
+		/// </summary>
+		/// <value>
+		/// The minutes of the current date if available.
+		/// </value>
+		public Int32? Minutes
+		{
+			get
+			{
+				return minutes;
+			}
+		}
+
+		/// <summary>
+		/// Gets the seconds of the current date if available.
+		/// </summary>
+		/// <value>
+		/// The seconds of the current date if available.
+		/// </value>
+		public Int32? Seconds
+		{
+			get
+			{
+				return seconds;
+			}
+		}
+
+		/// <summary>
+		/// Gets the timezone hours of the current date if available.
+		/// </summary>
+		/// <value>
+		/// The timezone hours of the current date if available.
+		/// </value>
+		public Int32? TzHours
+		{
+			get
+			{
+				return tzHours;
+			}
+		}
+
+		/// <summary>
+		/// Gets the timezone minutes of the current date if available.
+		/// </summary>
+		/// <value>
+		/// The timezone minutes of the current date if available.
+		/// </value>
+		public Int32? TzMinutes
+		{
+			get
+			{
+				return tzMinutes;
+			}
+		}
+	}
 }


### PR DESCRIPTION
Properties are easier to bind to and should be preferred over methods in .NET apps.